### PR TITLE
Update the docker to import content types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate-Germplasm
 RUN service postgresql restart \
   && drush trp-install-chado --schema-name=${chadoschema} \
   && drush trp-prep-chado --schema-name=${chadoschema} \
+  && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado \
+  && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado \
   && drush en trpcultivate_germplasm trpcultivate_germcollection --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ RUN service postgresql restart \
   && drush trp-prep-chado --schema-name=${chadoschema} \
   && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado \
   && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado \
-  && drush en trpcultivate_germplasm trpcultivate_germcollection --yes
+  && drush en trpcultivate_germplasm trpcultivate_germcollection --yes \
+  && drush cr


### PR DESCRIPTION
**Issue #9**

## Motivation

This PR is introducing the same fix to the dockerfile for importing content types as [PR#56 in TripalCultivate-Phenotypes](https://github.com/TripalCultivate/TripalCultivate-Phenotypes/pull/56) did. This fix is needed since Tripal Core PR https://github.com/tripal/tripal/pull/1696 was merged, and it changed the purpose of prepare and how content types were created. Note that the change in the phenotypes PR involving running trp-run-jobs was unnecessary for this module and thus has been left out of this PR.

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?

1. Adds drush commands to the dockerfile to import the General + Germplasm content type collections in core.
2. Adds a cache rebuild command (drush cr) to the end of the Dockerfile. This is needed to have the germplasm importers appear in the Data Loaders listing ( Admin > Tripal > Data Loaders ) immediately after installation of the module.

## Testing

### Manual Testing
See [PR#56 in TripalCultivate-Phenotypes](https://github.com/TripalCultivate/TripalCultivate-Phenotypes/pull/56) for step-by-step instructions including screenshots. 

Here are the specific commands I used for setting up my docker environment:
```
git clone https://github.com/TripalCultivate/TripalCultivate-Germplasm.git trpcultivate-g0.09
cd trpcultivate-g0.09
git checkout g0.09-importContentTypes
docker build --tag=trpcultivate:G0.09 ./
docker run --publish=8080:80 --name=trpcultivate-G0.09 -tid --volume=`pwd`:/var/www/drupal/web/modules/contrib/TripalCultivate-Germplasm trpcultivate:G0.09
docker exec trpcultivate-G0.09 service postgresql restart
```
Then I logged into the site and navigated to Admin > Tripal > Page Structure and confirmed that the expected content types were there.

I was also successfully able to create an organism through Admin > Tripal > Content > Add Tripal Content

I tried this change in my `g2.2-germAccessionImporter` branch and also confirmed that the Germplasm Accession Importer shows up in the listing at Admin > Tripal > Data Loaders 😄 
