### PR TITLE
Update dependencies and use new theme/base

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -1,6 +1,17 @@
 
 name: PHPUnit
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - 4.x
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 2am every night.
+    - cron: '0 2 * * *'
 
 env:
   PKG_NAME: TripalCultivate-Germplasm

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.4
         with:
           directory-name: $PKG_NAME
           modules: $MODULES

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -16,11 +16,20 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
+          - "8.3"
         pgsql-version:
           - "13"
         drupal-version:
           - "10.0.x-dev"
           - "10.1.x-dev"
+          - "10.2.x-dev"
+        exclude:
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "10.0.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "10.1.x-dev"
 
     steps:
       # Check out the repo

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -5,7 +5,7 @@ on: [push, workflow_dispatch]
 env:
   PKG_NAME: TripalCultivate-Germplasm
   MODULES: "trpcultivate_germplasm trpcultivate_germcollection"
-  IMAGE_TAG: drupal10.1.x-dev-php8.2-pgsql13
+  IMAGE_TAG: baseonly-drupal10.1.x-dev-php8.2-pgsql13
   SIMPLETEST_BASE_URL: "http://localhost"
   SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
   BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"
@@ -24,13 +24,13 @@ jobs:
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Pull TripalDocker Image
         run: |
-          docker pull tripalproject/tripaldocker:$IMAGE_TAG
+          docker pull knowpulse/tripalcultivate:$IMAGE_TAG
       # Just spin up docker the good ol' fashion way
       # mounting our currently checked out package inside the docker container.
       - name: Spin up Docker locally
         run: |
           docker run --publish=80:80 --name=tripaldocker -tid \
-            --volume=`pwd`:/var/www/drupal/web/modules/contrib/$PKG_NAME tripalproject/tripaldocker:$IMAGE_TAG
+            --volume=`pwd`:/var/www/drupal/web/modules/contrib/$PKG_NAME knowpulse/tripalcultivate:$IMAGE_TAG
       # Install the modules
       - name: Install our package in Docker
         run: |

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Pull TripalDocker Image
         run: |
@@ -38,7 +38,7 @@ jobs:
           docker exec tripaldocker drush en $MODULES --yes
       # Ensure we have the variables we need.
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4
       # Prepare for code coverage.
       - name: Prepare for Code Coverage
         run: |

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -1,6 +1,6 @@
 # Run some PHPUnit tests
 name: Test Coverage
-on: [push]
+on: [push, workflow_dispatch]
 
 env:
   PKG_NAME: TripalCultivate-Germplasm

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.4
         with:
           directory-name: 'TripalCultivate-Germplasm'
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -3,7 +3,14 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.4
         with:
           directory-name: 'TripalCultivate-Germplasm'
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -3,7 +3,14 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -19,4 +19,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: '8.1'
           pgsql-version: '13'
-          drupal-version: '10.1.x-dev'
+          drupal-version: '10.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -3,7 +3,14 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -17,6 +17,6 @@ jobs:
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
+          php-version: '8.2'
           pgsql-version: '13'
-          drupal-version: '10.1.x-dev'
+          drupal-version: '10.0.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.4
         with:
           directory-name: 'TripalCultivate-Germplasm'
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -3,7 +3,14 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.4
         with:
           directory-name: 'TripalCultivate-Germplasm'
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -3,7 +3,14 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -3,7 +3,14 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -17,6 +17,6 @@ jobs:
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
+          php-version: '8.2'
           pgsql-version: '13'
-          drupal-version: '10.1.x-dev'
+          drupal-version: '10.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -17,6 +17,6 @@ jobs:
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
+          php-version: '8.3'
           pgsql-version: '13'
-          drupal-version: '10.1.x-dev'
+          drupal-version: '10.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -3,7 +3,14 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-ARG drupalversion='10.1.x-dev'
-FROM tripalproject/tripaldocker:drupal${drupalversion}-php8.1-pgsql13-noChado
+ARG drupalversion='10.2.x-dev'
+ARG phpversion='8.3'
+ARG pgsqlversion='13'
+FROM knowpulse/tripalcultivate:baseonly-drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
 
-ARG chadoschema='testchado'
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate-Germplasm
-
 WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate-Germplasm
 
 RUN service postgresql restart \
-  && drush trp-install-chado --schema-name=${chadoschema} \
-  && drush trp-prep-chado --schema-name=${chadoschema} \
-  && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado \
-  && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado \
   && drush en trpcultivate_germplasm trpcultivate_germcollection --yes \
   && drush cr

--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-| Drupal      | 10.0.x          | 10.1.x          |
-|-------------|-----------------|-----------------|
-| **PHP 8.1** | ![Grid1A-Badge] | ![Grid1B-Badge] |
-| **PHP 8.2** | ![Grid2A-Badge] | ![Grid2B-Badge] |
+|  Drupal     |  10.0.x         |  10.1.x         |  10.2.x         |
+|-------------|-----------------|-----------------|-----------------|
+| **PHP 8.1** | ![Grid1A-Badge] | ![Grid1B-Badge] | ![Grid1C-Badge] |
+| **PHP 8.2** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] |
+| **PHP 8.3** |                 |                 | ![Grid3C-Badge] |
 
 [our CodeClimate project page]: https://codeclimate.com/github/TripalCultivate/TripalCultivate-Germplasm
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/0619dcf991bd5e5114fb/maintainability
@@ -72,6 +73,10 @@ The following compatibility is proven via automated testing workflows.
 
 [Grid1A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid1A.yml/badge.svg
 [Grid1B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid1B.yml/badge.svg
+[Grid1C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid1C.yml/badge.svg
 
 [Grid2A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid2A.yml/badge.svg
 [Grid2B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid2B.yml/badge.svg
+[Grid2C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid2C.yml/badge.svg
+
+[Grid3C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid3C.yml/badge.svg

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,9 @@
     }
   ],
   "require": {
-    "php": "^8.0",
-    "drupal/core": "^9.4",
-    "tripal/tripal": "^4.0-alpha1"
+    "php": "^8.1",
+    "drupal/core": "^10.0",
+    "tripal/tripal": "^4.0-alpha1",
+    "tripalcultivate/base": "*"
   }
 }

--- a/trpcultivate_germcollection/trpcultivate_germcollection.info.yml
+++ b/trpcultivate_germcollection/trpcultivate_germcollection.info.yml
@@ -2,7 +2,8 @@ name: Germplasm Collection
 type: module
 description: Provides support for grouping germplasm into collections and specialized Tripal fields.
 package: "TripalCultivate: Germplasm Collection"
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10
 dependencies:
   - tripal
   - tripal_chado
+  - trpcultivate

--- a/trpcultivate_germplasm/trpcultivate_germplasm.info.yml
+++ b/trpcultivate_germplasm/trpcultivate_germplasm.info.yml
@@ -2,7 +2,8 @@ name: Germplasm
 type: module
 description: Provides specialized Tripal fields and importers for germplasm.
 package: "TripalCultivate: Germplasm"
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10
 dependencies:
   - tripal
   - tripal_chado
+  - trpcultivate


### PR DESCRIPTION
**Issue #14**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->
Based on the changes made in https://github.com/TripalCultivate/TripalCultivate/pull/8 we need to update all the packages.

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Updates dependencies (i.e. Drupal version, Tripal Cultivate Base)
2. Dockerfile now uses TripalCultivate base image instead of Tripal core
3. Update all github action versions to remove warning about Node 20
4. Update automated testing grid to include Drupal 10.2 and PHP 8.2
5. Update all workflows to allow them to be manually triggered and to ensure they are run each night on the most recent changes in dependencies.

**NOTE: This module is not yet compatible with Drupal 10.2 so the failing tests for that version of Drupal are expected. This will be fixed in Issue #16**

## Testing

### Automated Testing
No additional automated testing needed for these changes.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Check that the automated testing passes. This confirms changes to dependancies, workflows and the Dockerfile did not cause any issues.
2. Build a docker image locally and run a container just to take a look at things.
    - everything is installed and chado is in a schema named `testschema`
    - the content types you expect are available (note: additionally the genetic and genomic will now be available).
    - confirm that the site is now themed green as expected for Tripal Cultivate.