### PR TITLE
Support added to ensure compatibility with Drupal 10.2 + PHP 8.3

### DIFF
--- a/trpcultivate_germcollection/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_germcollection/tests/src/Functional/InstallTest.php
@@ -69,10 +69,14 @@ class InstallTest extends ChadoTestBrowserBase {
   public function testHelp() {
     $session = $this->getSession();
 
-    $some_extected_text = self::$help_text_excerpt;
+    $some_expected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $user = $this->drupalCreateUser(['access administration pages', 'administer modules']);
+    $permissions = ['access administration pages', 'administer modules'];
+    if (strncmp(\Drupal::VERSION, '10.2', 4) === 0) {
+      $permissions[] = 'access help pages';
+    }
+    $user = $this->drupalCreateUser($permissions);
     $this->drupalLogin($user);
 
     $context = '(modules installed: ' . implode(',', self::$modules) . ')';
@@ -83,7 +87,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $hook_name = self::$module_machinename . '_help';
     $output = $hook_name($name, $match);
     $this->assertNotEmpty($output, "The help hook should return output $context.");
-    $this->assertStringContainsString($some_extected_text, $output);
+    $this->assertStringContainsString($some_expected_text, $output);
 
     // Help Page.
     $this->drupalGet('admin/help');
@@ -93,7 +97,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $this->drupalGet('admin/help/' . self::$module_machinename);
     $status_code = $session->getStatusCode();
     $this->assertEquals(200, $status_code, "The module help page should be able to load $context.");
-    $this->assertSession()->pageTextContains($some_extected_text);
+    $this->assertSession()->pageTextContains($some_expected_text);
   }
 
 }

--- a/trpcultivate_germplasm/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_germplasm/tests/src/Functional/InstallTest.php
@@ -14,6 +14,13 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
 class InstallTest extends ChadoTestBrowserBase {
 
   protected $defaultTheme = 'stark';
+  
+  /**
+   * The service for retreiving a connection with Chado.
+   *
+   * @var Drupal\tripal_chado\Database\ChadoConnection
+   */
+  protected $connection;
 
   /**
    * Modules to enable.
@@ -88,10 +95,14 @@ class InstallTest extends ChadoTestBrowserBase {
   public function testHelp() {
     $session = $this->getSession();
 
-    $some_extected_text = self::$help_text_excerpt;
+    $some_expected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $user = $this->drupalCreateUser(['access administration pages', 'administer modules']);
+    $permissions = ['access administration pages', 'administer modules'];
+    if (strncmp(\Drupal::VERSION, '10.2', 4) === 0) {
+      $permissions[] = 'access help pages';
+    }
+    $user = $this->drupalCreateUser($permissions);
     $this->drupalLogin($user);
 
     $context = '(modules installed: ' . implode(',', self::$modules) . ')';
@@ -102,7 +113,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $hook_name = self::$module_machinename . '_help';
     $output = $hook_name($name, $match);
     $this->assertNotEmpty($output, "The help hook should return output $context.");
-    $this->assertStringContainsString($some_extected_text, $output);
+    $this->assertStringContainsString($some_expected_text, $output);
 
     // Help Page.
     $this->drupalGet('admin/help');
@@ -112,7 +123,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $this->drupalGet('admin/help/' . self::$module_machinename);
     $status_code = $session->getStatusCode();
     $this->assertEquals(200, $status_code, "The module help page should be able to load $context.");
-    $this->assertSession()->pageTextContains($some_extected_text);
+    $this->assertSession()->pageTextContains($some_expected_text);
   }
 
 }

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterRunTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterRunTest.php
@@ -21,6 +21,10 @@ class GermplasmAccessionImporterRunTest extends ChadoTestKernelBase {
 
   protected $importer;
 
+  protected $config_factory;
+
+  protected $connection;
+
   protected $logger;
 
   protected $definitions = [

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterTest.php
@@ -19,6 +19,10 @@ class GermplasmAccessionImporterTest extends ChadoTestKernelBase {
 
   protected $importer;
 
+  protected $config_factory;
+
+  protected $connection;
+
   protected $definitions = [
     'test-germplasm-accession' => [
       'id' => 'trpcultivate-germplasm-accession',


### PR DESCRIPTION
**Issue #16**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

Automated tests were failing for this module on Drupal 10.2 and PHP 8.3. There were 2 failed tests and multiple deprecation notices. The goal is to fix these while maintaining support with Drupal 10.0 & 10.1, PHP 8.1 & 8.2.

## What does this PR do?

1. Removes PHP deprecation notices by declaring the services `$connection` and `$config_factory` where appropriate in Kernel tests
2. Fixes failing tests for admin help pages in `InstallTest.php` for both trpcultivate_germcollection and trpcultivate_germplasm. The approach for this was borrowed from the fix for the same problem by @laceysanderson in Tripal Cultivate Phenotypes: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/commit/aff9a2c9f6d5360cb3cda996b13f297dbc0ee2d7 This approach _should_ work with future Drupal upgrades, assuming the same requirements for permissions are present in those versions.
3. Fixed a typo in both `InstallTest.php` files since I happened to notice it 😅  From "extected" -> "expected"

## Testing

### Automated Testing
No additional automated tests were added.

### Manual Testing
Make sure that _all_ automated tests are passing. Not sure what else can be tested manually, as the automated tests failing did not impact the ability to access the admin help pages through the interface (admin/help). But, maybe it wouldn't hurt to make sure that's still working fine? :wink: