### PR TITLE
Update Docker in this module to newer versions and base image.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,9 +30,9 @@ checks:
     config:
       threshold: 6
   return-statements:
-    enabled: true
+    enabled: false
     config:
-      threshold: 6
+      threshold: 100
   similar-code:
     enabled: false
     config:

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,144 @@
+{
+  "name": "TripalDocker",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "drupalversion": "11.1.x-dev",
+      "phpversion": "8.3",
+      "pgsqlversion": "16"
+    }
+  },
+  "initializeCommand": "docker pull knowpulse/tripalcultivate-base:drupal11.1.x-dev-php8.3-pgsql16",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/drupal/web/modules/contrib/TripalCultivate-Germplasm,type=bind",
+  "workspaceFolder": "/var/www/drupal/web/modules/contrib/TripalCultivate-Germplasm",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "neilbrayfield.php-docblocker",
+        "bmewburn.vscode-intelephense-client",
+        "recca0120.vscode-phpunit",
+        "swordev.phpstan",
+        "andrewdavidblum.drupal-smart-snippets",
+        "DEVSENSE.composer-php-vscode",
+        "mblode.twig-language-2",
+        "redhat.vscode-yaml",
+        "ms-azuretools.vscode-docker",
+        "github.vscode-github-actions",
+        "GitHub.vscode-pull-request-github",
+        "valeryanm.vscode-phpsab"
+      ],
+      "settings": {
+        // This turns off basic PHP suggestions provided by Visual Studio Code (in lieu of Intelephense's).
+        "php.suggest.basic": false,
+        /* Coding Standards */
+        "css.validate": true,
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.tabSize": 2,
+        "editor.autoIndent": "full",
+        "editor.insertSpaces": true,
+        "editor.formatOnPaste": true,
+        "editor.formatOnSave": false,
+        "editor.renderWhitespace": "boundary",
+        "editor.wordWrapColumn": 80,
+        "editor.wordWrap": "on",
+        "editor.detectIndentation": true,
+        "editor.rulers": [
+          80
+        ],
+        "files.trimTrailingWhitespace": true,
+        "files.insertFinalNewline": true,
+        "files.trimFinalNewlines": true,
+        "html.format.enable": true,
+        "html.format.wrapLineLength": 80,
+        /* Chosing which language a file is; Drupal-focused */
+        "files.associations": {
+          "*.inc": "php",
+          "*.module": "php",
+          "*.install": "php",
+          "*.theme": "php",
+          "*.profile": "php",
+          "*.tpl.php": "php",
+          "*.test": "php",
+          "*.php": "php",
+          "*.info": "ini",
+          "*.html": "twig"
+        },
+        "emmet.includeLanguages": {
+          "twig": "html"
+        },
+        /* Performance Related. Exludes from indexing */
+        /*files.exclude and files.watcherExclude settings via https://github.com/microsoft/vscode/issues/11963#issuecomment-317830768 */
+        "files.exclude": {
+          "**/.git": true,
+          "**/.svn": true,
+          "**/.hg": true,
+          "**/CVS": true,
+          "**/.DS_Store": true,
+          "**/tmp": true,
+          "**/node_modules": true,
+          "**/bower_components": true,
+          "**/dist": true
+        },
+        "files.watcherExclude": {
+          "**/.git/objects/**": true,
+          "**/.git/subtree-cache/**": true,
+          "**/node_modules/**": true,
+          "**/tmp/**": true,
+          "**/bower_components/**": true,
+          "**/dist/**": true
+        },
+        /* PHP Linting */
+        "php.validate.enable": true,
+        "php.validate.executablePath": "/usr/local/bin/php",
+        "php.validate.run": "onType",
+        "[php]": {
+          "editor.defaultFormatter": "valeryanm.vscode-phpsab"
+        },
+        /* PHP DocBlocker */
+        "php-docblocker.gap": true,
+        "php-docblocker.useShortNames": true,
+        /* PHP Intelephense */
+        // Intelephense and Drupal >8 only. This should be set to the path to web/index.php.
+        "intelephense.environment.documentRoot": "/var/www/drupal/web/index.php",
+        // Intelephense only: For Drupal compliant braces formatting use:
+        "intelephense.format.braces": "k&r",
+        // Indicate where to find additional classes.
+        "intelephense.environment.includePaths": [
+          "/var/www/drupal/web/core/",
+          "/var/www/drupal/vendor/",
+          "/var/www/drupal/web/modules/"
+        ],
+        "intelephense.diagnostics.enable": false,
+        /* PHPUnit Test Explorer */
+        "phpunit.phpunit": "/var/www/drupal/vendor/bin/phpunit",
+        /* Drupal Smart Snippets */
+        // Use this to prioritize Drupal Smart Snippets in the UI.
+        "editor.snippetSuggestions": "top",
+        /* Composer */
+        "composer.bin": "/usr/local/bin/composer",
+        "tws.trimOnSave": true,
+        "tws.highlightTrailingWhiteSpace": true,
+        /* PHP Sniffer & Beautifier */
+        "phpsab.snifferEnable": true,
+        "phpsab.executablePathCS": "/var/www/drupal/vendor/bin/phpcs",
+        "phpsab.fixerEnable": true,
+        "phpsab.executablePathCBF": "/var/www/drupal/vendor/bin/phpcbf",
+        "phpsab.standard": "/var/www/drupal/web/modules/contrib/TripalCultivate/.codingstandards.xml",
+        "phpsab.snifferMode": "onType",
+        "phpsab.debug": false,
+        "phpsab.fixerArguments": [
+          "--extensions=inc,theme,install,module,profile,php,phtml"
+        ],
+        "phpsab.snifferArguments": [
+          "--extensions=inc,theme,install,module,profile,php,phtml"
+        ]
+      }
+    }
+  },
+  "forwardPorts": [
+    80,
+    5432,
+    9003
+  ],
+  "postCreateCommand": "init.sh"
+}

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -1,5 +1,5 @@
 
-name: PHPUnit
+name: PHPUnit Full Test Suite
 on:
   push:
     branches-ignore:
@@ -19,6 +19,7 @@ env:
 
 jobs:
   run-tests:
+    name: "Drupal ${{ matrix.drupal-version }} - PHP ${{ matrix.php-version }} - PostgreSQL ${{ matrix.pgsql-version }}"
     runs-on: ubuntu-latest
 
     strategy:
@@ -30,17 +31,28 @@ jobs:
           - "8.3"
         pgsql-version:
           - "13"
+          - "16"
         drupal-version:
-          - "10.0.x-dev"
-          - "10.1.x-dev"
-          - "10.2.x-dev"
+          - "10.3.x-dev"
+          - "10.4.x-dev"
+          - "10.5.x-dev"
+          - "11.0.x-dev"
+          - "11.1.x-dev"
         exclude:
+          - php-version: "8.1"
+            drupal-version: "11.0.x-dev"
+          - php-version: "8.2"
+            drupal-version: "11.0.x-dev"
           - php-version: "8.3"
             pgsql-version: "13"
-            drupal-version: "10.0.x-dev"
+            drupal-version: "11.0.x-dev"
+          - php-version: "8.1"
+            drupal-version: "11.1.x-dev"
+          - php-version: "8.2"
+            drupal-version: "11.1.x-dev"
           - php-version: "8.3"
             pgsql-version: "13"
-            drupal-version: "10.1.x-dev"
+            drupal-version: "11.1.x-dev"
 
     steps:
       # Check out the repo
@@ -48,7 +60,7 @@ jobs:
         uses: actions/checkout@v4
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: $PKG_NAME
           modules: $MODULES
@@ -57,4 +69,3 @@ jobs:
           php-version: ${{ matrix.php-version }}
           pgsql-version: ${{ matrix.pgsql-version }}
           drupal-version: ${{ matrix.drupal-version }}
-

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -2,73 +2,24 @@
 name: Test Coverage
 on: [push, workflow_dispatch]
 
-env:
-  PKG_NAME: TripalCultivate-Germplasm
-  MODULES: "trpcultivate_germplasm trpcultivate_germcollection"
-  IMAGE_TAG: baseonly-drupal10.1.x-dev-php8.2-pgsql13
-  SIMPLETEST_BASE_URL: "http://localhost"
-  SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
-  BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"
+## UPDATES
+## Update the version numbers in the job name and the action parameters
 
 jobs:
-  # Job 1: 'build'
-  run-tests:
-    # Runner type
+  run-coverage:
+    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
-    name: Test Coverage
-
     steps:
-      # Check out the repo
       - name: Checkout Repository
         uses: actions/checkout@v4
-      # Here we pull the development tripaldocker image for this combo in our matrix
-      - name: Pull TripalDocker Image
-        run: |
-          docker pull knowpulse/tripalcultivate:$IMAGE_TAG
-      # Just spin up docker the good ol' fashion way
-      # mounting our currently checked out package inside the docker container.
-      - name: Spin up Docker locally
-        run: |
-          docker run --publish=80:80 --name=tripaldocker -tid \
-            --volume=`pwd`:/var/www/drupal/web/modules/contrib/$PKG_NAME knowpulse/tripalcultivate:$IMAGE_TAG
-      # Install the modules
-      - name: Install our package in Docker
-        run: |
-          docker exec tripaldocker service postgresql restart
-          docker exec tripaldocker drush en $MODULES --yes
-      # Ensure we have the variables we need.
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
-      # Prepare for code coverage.
-      - name: Prepare for Code Coverage
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          docker cp cc-test-reporter tripaldocker:/var/www/drupal/web/modules/contrib/$PKG_NAME
-          docker exec tripaldocker chmod a+x /var/www/drupal/web/modules/contrib/$PKG_NAME/cc-test-reporter
-          docker exec --workdir=/var/www/drupal/web/modules/contrib/$PKG_NAME tripaldocker ./cc-test-reporter before-build --debug
-      # Runs the PHPUnit tests.
-      # https://github.com/mheap/phpunit-github-actions-printer is used
-      # to report PHPUnit fails in a meaningful way to github in PRs.
-      # Stopped using mheap due to warning w/ phpunit8->9
-      - name: Run Tests for Coverage
-        env:
-          SIMPLETEST_BASE_URL: "http://localhost"
-          SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
-          BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"
-        run: |
-          docker exec tripaldocker service postgresql restart
-          docker exec -e SIMPLETEST_BASE_URL=$SIMPLETEST_BASE_URL \
-            -e SIMPLETEST_DB=$SIMPLETEST_DB \
-            -e BROWSER_OUTPUT_DIRECTORY=$BROWSER_OUTPUT_DIRECTORY \
-            --workdir=/var/www/drupal/web/modules/contrib/$PKG_NAME \
-            tripaldocker phpunit --coverage-text \
-              --coverage-clover /var/www/drupal/web/modules/contrib/$PKG_NAME/clover.xml
-          docker exec tripaldocker ls /var/www/drupal/web/modules/contrib/$PKG_NAME
-      - name: Publish code coverage to Code Climate
-        run: |
-          docker exec --workdir=/var/www/drupal/web/modules/contrib/$PKG_NAME tripaldocker \
-            git config --global --add safe.directory /var/www/drupal/web/modules/contrib/$PKG_NAME
-          docker exec --workdir=/var/www/drupal/web/modules/contrib/$PKG_NAME \
-            tripaldocker ./cc-test-reporter after-build clover.xml \
-            --id ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }} \
-            --debug -t clover -p /var/www/drupal/web/modules/contrib/$PKG_NAME
+      - name: Run Automated testing + report coverage
+        uses: tripal/test-tripal-action@v1.6
+        with:
+          directory-name: 'TripalCultivate-Germplasm'
+          modules: 'trpcultivate_germplasm trpcultivate_germcollection'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
+          php-version: 8.3
+          pgsql-version: 16
+          drupal-version: 10.4.x-dev
+          codeclimate-reporter-id: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -3,27 +3,30 @@ on:
   push:
     branches:
       - 4.x
-  # Allows us to manually trigger this workflow.
-  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
-  workflow_dispatch:
-  # Allows us to schedule when this workflow is run.
-  # This ensures we pick up any new changes committed to Tripal Core.
-  schedule:
-    # Run at 4am every morning.
-    - cron: '0 4 * * *'
+      - laceysanderson-patch-1
+
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+
 jobs:
-  run-tests:
+  grid-1A:
+    name: "Drupal 10.3.x-dev - PHP 8.1 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Germplasm'
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
-          pgsql-version: '13'
-          drupal-version: '10.0.x-dev'
+          php-version: 8.1
+          pgsql-version: 16
+          drupal-version: 10.3.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -3,27 +3,30 @@ on:
   push:
     branches:
       - 4.x
-  # Allows us to manually trigger this workflow.
-  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
-  workflow_dispatch:
-  # Allows us to schedule when this workflow is run.
-  # This ensures we pick up any new changes committed to Tripal Core.
-  schedule:
-    # Run at 4am every morning.
-    - cron: '0 4 * * *'
+      - laceysanderson-patch-1
+
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+
 jobs:
-  run-tests:
+  grid-1B:
+    name: "Drupal 10.3.x-dev - PHP 8.2 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Germplasm'
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
-          pgsql-version: '13'
-          drupal-version: '10.1.x-dev'
+          php-version: 8.2
+          pgsql-version: 16
+          drupal-version: 10.3.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -3,27 +3,30 @@ on:
   push:
     branches:
       - 4.x
-  # Allows us to manually trigger this workflow.
-  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
-  workflow_dispatch:
-  # Allows us to schedule when this workflow is run.
-  # This ensures we pick up any new changes committed to Tripal Core.
-  schedule:
-    # Run at 4am every morning.
-    - cron: '0 4 * * *'
+      - laceysanderson-patch-1
+
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+
 jobs:
-  run-tests:
+  grid-1C:
+    name: "Drupal 10.3.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Germplasm'
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
-          pgsql-version: '13'
-          drupal-version: '10.2.x-dev'
+          php-version: 8.3
+          pgsql-version: 16
+          drupal-version: 10.3.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -3,27 +3,30 @@ on:
   push:
     branches:
       - 4.x
-  # Allows us to manually trigger this workflow.
-  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
-  workflow_dispatch:
-  # Allows us to schedule when this workflow is run.
-  # This ensures we pick up any new changes committed to Tripal Core.
-  schedule:
-    # Run at 4am every morning.
-    - cron: '0 4 * * *'
+      - laceysanderson-patch-1
+
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+
 jobs:
-  run-tests:
+  grid-2A:
+    name: "Drupal 10.4.x-dev - PHP 8.1 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Germplasm'
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.2'
-          pgsql-version: '13'
-          drupal-version: '10.0.x-dev'
+          php-version: 8.1
+          pgsql-version: 16
+          drupal-version: 10.4.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -3,27 +3,30 @@ on:
   push:
     branches:
       - 4.x
-  # Allows us to manually trigger this workflow.
-  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
-  workflow_dispatch:
-  # Allows us to schedule when this workflow is run.
-  # This ensures we pick up any new changes committed to Tripal Core.
-  schedule:
-    # Run at 4am every morning.
-    - cron: '0 4 * * *'
+      - laceysanderson-patch-1
+
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+
 jobs:
-  run-tests:
+  grid-2B:
+    name: "Drupal 10.4.x-dev - PHP 8.2 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Germplasm'
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.2'
-          pgsql-version: '13'
-          drupal-version: '10.1.x-dev'
+          php-version: 8.2
+          pgsql-version: 16
+          drupal-version: 10.4.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid3A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3A.yml
@@ -14,8 +14,8 @@ on:
 ## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
-  grid-2C:
-    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 16"
+  grid-3A:
+    name: "Drupal 10.5.x-dev - PHP 8.1 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -27,6 +27,6 @@ jobs:
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: 8.3
+          php-version: 8.1
           pgsql-version: 16
-          drupal-version: 10.4.x-dev
+          drupal-version: 10.5.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid3B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3B.yml
@@ -14,8 +14,8 @@ on:
 ## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
-  grid-2C:
-    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 16"
+  grid-3B:
+    name: "Drupal 10.5.x-dev - PHP 8.2 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -27,6 +27,6 @@ jobs:
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: 8.3
+          php-version: 8.2
           pgsql-version: 16
-          drupal-version: 10.4.x-dev
+          drupal-version: 10.5.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -3,27 +3,30 @@ on:
   push:
     branches:
       - 4.x
-  # Allows us to manually trigger this workflow.
-  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
-  workflow_dispatch:
-  # Allows us to schedule when this workflow is run.
-  # This ensures we pick up any new changes committed to Tripal Core.
-  schedule:
-    # Run at 4am every morning.
-    - cron: '0 4 * * *'
+      - laceysanderson-patch-1
+
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+
 jobs:
-  run-tests:
+  grid-3C:
+    name: "Drupal 10.5.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Germplasm'
           modules: 'trpcultivate_germplasm trpcultivate_germcollection'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.3'
-          pgsql-version: '13'
-          drupal-version: '10.2.x-dev'
+          php-version: 8.3
+          pgsql-version: 16
+          drupal-version: 10.5.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid4C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid4C.yml
@@ -14,8 +14,8 @@ on:
 ## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
-  grid-2C:
-    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 16"
+  grid-4C:
+    name: "Drupal 11.0.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,4 +29,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.3
           pgsql-version: 16
-          drupal-version: 10.4.x-dev
+          drupal-version: 11.0.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid5C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid5C.yml
@@ -14,8 +14,8 @@ on:
 ## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
-  grid-2C:
-    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 16"
+  grid-5C:
+    name: "Drupal 11.1.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,4 +29,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.3
           pgsql-version: 16
-          drupal-version: 10.4.x-dev
+          drupal-version: 11.1.x-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG drupalversion='10.2.x-dev'
-ARG phpversion='8.3'
-ARG pgsqlversion='13'
-FROM knowpulse/tripalcultivate:baseonly-drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
+ARG drupalversion=11.1.x-dev
+ARG phpversion=8.3
+ARG pgsqlversion=16
+FROM knowpulse/tripalcultivate-base:drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
 
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate-Germplasm
 WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate-Germplasm

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-|  Drupal     |  10.0.x         |  10.1.x         |  10.2.x         |
-|-------------|-----------------|-----------------|-----------------|
-| **PHP 8.1** | ![Grid1A-Badge] | ![Grid1B-Badge] | ![Grid1C-Badge] |
-| **PHP 8.2** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] |
-| **PHP 8.3** |                 |                 | ![Grid3C-Badge] |
+|  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+|-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+| **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+| **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+| **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 [our CodeClimate project page]: https://codeclimate.com/github/TripalCultivate/TripalCultivate-Germplasm
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/0619dcf991bd5e5114fb/maintainability
@@ -79,4 +79,10 @@ The following compatibility is proven via automated testing workflows.
 [Grid2B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid2B.yml/badge.svg
 [Grid2C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid2C.yml/badge.svg
 
+[Grid3A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid3A.yml/badge.svg
+[Grid3B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid3B.yml/badge.svg
 [Grid3C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid3C.yml/badge.svg
+
+[Grid4C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid4C.yml/badge.svg
+
+[Grid5C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Germplasm/actions/workflows/MAIN-phpunit-Grid5C.yml/badge.svg

--- a/trpcultivate_germcollection/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_germcollection/tests/src/Functional/InstallTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\trpcultivate_germcollection\Functional;
 
+use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Url;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
 
@@ -23,7 +24,7 @@ class InstallTest extends ChadoTestBrowserBase {
   protected static $modules = ['help', 'trpcultivate_germcollection'];
 
   /**
-   * The name of your module in the .info.yml
+   * The name of your module in the .info.yml.
    */
   protected static $module_name = 'Germplasm Collection';
 
@@ -59,7 +60,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $this->drupalGet('admin/modules');
     $status_code = $session->getStatusCode();
     $this->assertEquals(200, $status_code, "The module install page should be able to load $context.");
-    $this->assertSession()->pageTextContains( self::$module_name );
+    $this->assertSession()->pageTextContains(self::$module_name);
 
   }
 
@@ -72,10 +73,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_expected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $permissions = ['access administration pages', 'administer modules'];
-    if (strncmp(\Drupal::VERSION, '10.2', 4) === 0) {
-      $permissions[] = 'access help pages';
-    }
+    $permissions = ['access administration pages', 'administer modules', 'access help pages'];
     $user = $this->drupalCreateUser($permissions);
     $this->drupalLogin($user);
 
@@ -83,7 +81,7 @@ class InstallTest extends ChadoTestBrowserBase {
 
     // Call the hook to ensure it is returning text.
     $name = 'help.page.' . $this::$module_machinename;
-    $match = $this->createStub(\Drupal\Core\Routing\RouteMatch::class);
+    $match = $this->createStub(RouteMatch::class);
     $hook_name = self::$module_machinename . '_help';
     $output = $hook_name($name, $match);
     $this->assertNotEmpty($output, "The help hook should return output $context.");

--- a/trpcultivate_germcollection/trpcultivate_germcollection.info.yml
+++ b/trpcultivate_germcollection/trpcultivate_germcollection.info.yml
@@ -2,8 +2,8 @@ name: Germplasm Collection
 type: module
 description: Provides support for grouping germplasm into collections and specialized Tripal fields.
 package: "TripalCultivate: Germplasm Collection"
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 dependencies:
-  - tripal
-  - tripal_chado
-  - trpcultivate
+  - tripal:tripal
+  - tripal:tripal_chado
+  - trpcultivate:trpcultivate

--- a/trpcultivate_germplasm/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_germplasm/tests/src/Functional/InstallTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\trpcultivate_germplasm\Functional;
 
+use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Url;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
 
@@ -14,7 +15,7 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
 class InstallTest extends ChadoTestBrowserBase {
 
   protected $defaultTheme = 'stark';
-  
+
   /**
    * The service for retreiving a connection with Chado.
    *
@@ -30,7 +31,7 @@ class InstallTest extends ChadoTestBrowserBase {
   protected static $modules = ['help', 'tripal_chado'];
 
   /**
-   * The name of your module in the .info.yml
+   * The name of your module in the .info.yml.
    */
   protected static $module_name = 'Germplasm';
 
@@ -55,7 +56,7 @@ class InstallTest extends ChadoTestBrowserBase {
     // Ensure we see all logging in tests.
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
-    // Open connection to Chado
+    // Open connection to Chado.
     $this->connection = $this->getTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
 
     $moduleHandler = $this->container->get('module_handler');
@@ -85,7 +86,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $this->drupalGet('admin/modules');
     $status_code = $session->getStatusCode();
     $this->assertEquals(200, $status_code, "The module install page should be able to load $context.");
-    $this->assertSession()->pageTextContains( self::$module_name );
+    $this->assertSession()->pageTextContains(self::$module_name);
 
   }
 
@@ -98,10 +99,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_expected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $permissions = ['access administration pages', 'administer modules'];
-    if (strncmp(\Drupal::VERSION, '10.2', 4) === 0) {
-      $permissions[] = 'access help pages';
-    }
+    $permissions = ['access administration pages', 'administer modules', 'access help pages'];
     $user = $this->drupalCreateUser($permissions);
     $this->drupalLogin($user);
 
@@ -109,7 +107,7 @@ class InstallTest extends ChadoTestBrowserBase {
 
     // Call the hook to ensure it is returning text.
     $name = 'help.page.' . $this::$module_machinename;
-    $match = $this->createStub(\Drupal\Core\Routing\RouteMatch::class);
+    $match = $this->createStub(RouteMatch::class);
     $hook_name = self::$module_machinename . '_help';
     $output = $hook_name($name, $match);
     $this->assertNotEmpty($output, "The help hook should return output $context.");

--- a/trpcultivate_germplasm/trpcultivate_germplasm.info.yml
+++ b/trpcultivate_germplasm/trpcultivate_germplasm.info.yml
@@ -2,8 +2,8 @@ name: Germplasm
 type: module
 description: Provides specialized Tripal fields and importers for germplasm.
 package: "TripalCultivate: Germplasm"
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 dependencies:
-  - tripal
-  - tripal_chado
-  - trpcultivate
+  - tripal:tripal
+  - tripal:tripal_chado
+  - trpcultivate:trpcultivate


### PR DESCRIPTION
## Motivation

Based on the changes made in https://github.com/TripalCultivate/TripalCultivate/pull/8 we need to update all the packages.

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

- [x] Updates dependencies (i.e. Drupal version, Tripal Cultivate Base)
- [x] Adds devcontainer support
- [x] Dockerfile now uses TripalCultivate base image instead of Tripal core
- [x] Update all github action versions to remove warning about Node 20
- [x] Update automated testing grid to include Drupal 11 and PHP 8.3
- [x] Update all workflows to allow them to be manually triggered and to ensure they are run each night on the most recent changes in dependencies.
- [x] Update modules to be compatible with Drupal 11.

## Testing

### Automated Testing
No additional automated testing needed for these changes.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Check that the automated testing passes. This confirms changes to dependencies, workflows and the Dockerfile did not cause any issues.
2. Build a docker image locally and run a container just to take a look at things.
    - everything is installed and chado is in a schema named `testchado`
    - the content types you expect are available (note: additionally the genetic and genomic will now be available).
    - check the drupal, php, postgresql versions now match the newer defaults.
3. Check the readme testing grid on this branch is updated: https://github.com/TripalCultivate/TripalCultivate-Germplasm/tree/laceysanderson-patch-1?tab=readme-ov-file#automated-testing