### PR TITLE
G4.29 Migrate from Annotations to PHP Attributes

### DIFF
--- a/trpcultivate_germcollection/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_germcollection/tests/src/Functional/InstallTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\trpcultivate_germcollection\Functional;
 use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Url;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Simple test to ensure that main page loads with module enabled.
@@ -12,6 +13,8 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  * @group TripalCultivate-Germplasm
  * @group Installation
  */
+#[Group('TripalCultivate-Germplasm')]
+#[Group('Installation')]
 class InstallTest extends ChadoTestBrowserBase {
 
   protected $defaultTheme = 'stark';

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmAccessionImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmAccessionImporter.php
@@ -12,6 +12,22 @@ use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
 /**
  * Provides an importer for loading germplasm accessions from a tab-delimited
  * file.
+ *
+ * @TripalImporter(
+ *   id = "trpcultivate-germplasm-accession",
+ *   label = @Translation("Tripal Cultivate: Germplasm Accessions"),
+ *   description = @Translation("Imports germplasm accessions into Chado with metadata meeting BrAPI standards."),
+ *   file_types = {"tsv", "txt"},
+ *   use_analysis = FALSE,
+ *   require_analysis = FALSE,
+ *   upload_title = "Germplasm Accession Import",
+ *   button_text = "Import Germplasm Accessions",
+ *   file_upload = True,
+ *   file_load = True,
+ *   file_remote = True,
+ *   file_required = True,
+ *   cardinality = 1
+ * )
  */
 #[TripalImporter(
    id: 'trpcultivate-germplasm-accession',

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmAccessionImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmAccessionImporter.php
@@ -6,27 +6,28 @@ use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
 
 /**
  * Provides an importer for loading germplasm accessions from a tab-delimited
  * file.
- *
- * @TripalImporter(
- *   id = "trpcultivate-germplasm-accession",
- *   label = @Translation("Tripal Cultivate: Germplasm Accessions"),
- *   description = @Translation("Imports germplasm accessions into Chado with metadata meeting BrAPI standards."),
- *   file_types = {"tsv", "txt"},
- *   use_analysis = FALSE,
- *   require_analysis = FALSE,
- *   upload_title = "Germplasm Accession Import",
- *   button_text = "Import Germplasm Accessions",
- *   file_upload = True,
- *   file_load = True,
- *   file_remote = True,
- *   file_required = True,
- *   cardinality = 1
- * )
  */
+#[TripalImporter(
+   id: 'trpcultivate-germplasm-accession',
+   label: new TranslatableMarkup('Tripal Cultivate: Germplasm Accessions'),
+   description: new TranslatableMarkup('Imports germplasm accessions into Chado with metadata meeting BrAPI standards.'),
+   file_types: ['tsv', 'txt'],
+   use_analysis: FALSE,
+   require_analysis: FALSE,
+   upload_title: new TranslatableMarkup('Germplasm Accession Import'),
+   button_text: new TranslatableMarkup('Import Germplasm Accessions'),
+   file_upload: TRUE,
+   file_local: TRUE,
+   file_remote: TRUE,
+   file_required: TRUE,
+   cardinality: 1
+ )]
 class GermplasmAccessionImporter extends ChadoImporterBase {
 
   /**

--- a/trpcultivate_germplasm/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_germplasm/tests/src/Functional/InstallTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\trpcultivate_germplasm\Functional;
 use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Url;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Simple test to ensure that main page loads with module enabled.
@@ -12,6 +13,8 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  * @group TripalCultivate-Germplasm
  * @group Installation
  */
+#[Group('TripalCultivate-Germplasm')]
+#[Group('Installation')]
 class InstallTest extends ChadoTestBrowserBase {
 
   protected $defaultTheme = 'stark';

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterRunTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterRunTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Url;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\Tests\trpcultivate_germplasm\Traits\GermplasmAccessionImporterTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the functionality of the Germplasm Accession Importer.
@@ -142,6 +143,7 @@ class GermplasmAccessionImporterRunTest extends ChadoTestKernelBase {
    *
    * @group germ_accession_importer
    */
+  #[Group('germ_accession_importer')]
   public function testGermplasmAccessionImporterRunSimple() {
 
     $simple_example_file = __DIR__ . '/../../../Fixtures/simple_example.txt';
@@ -189,6 +191,7 @@ class GermplasmAccessionImporterRunTest extends ChadoTestKernelBase {
    *
    * @group germ_accession_importer
    */
+  #[Group('germ_accession_importer')]
   public function testGermplasmAccessionImporterRunMissing() {
 
     $problem_example_file = __DIR__ . '/../../../Fixtures/missing_required_example.txt';
@@ -226,6 +229,7 @@ class GermplasmAccessionImporterRunTest extends ChadoTestKernelBase {
    *
    * @group germ_accession_importer
    */
+  #[Group('germ_accession_importer')]
   public function testGermplasmAccessionImporterRunComplex() {
 
     $complex_example_file = __DIR__ . '/../../../Fixtures/props_syns_example.txt';
@@ -319,6 +323,7 @@ class GermplasmAccessionImporterRunTest extends ChadoTestKernelBase {
    *
    * @group germ_accession_importer
    */
+  #[Group('germ_accession_importer')]
   public function testGermplasmAccessionImporterRunIncomplete() {
 
     // Test for a non-existant file

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\trpcultivate_germplasm\Kernel\TripalImporter;
 use Drupal\Core\Url;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_germplasm\Traits\GermplasmAccessionImporterTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the functionality of the Germplasm Accession Importer.
@@ -110,6 +111,7 @@ class GermplasmAccessionImporterTest extends ChadoTestKernelBase {
    *
    * @group germ_accession_importer
    */
+  #[Group('germ_accession_importer')]
   public function testGermplasmAccessionImporterForm() {
 
 		$plugin_id = 'trpcultivate-germplasm-accession';
@@ -158,6 +160,7 @@ class GermplasmAccessionImporterTest extends ChadoTestKernelBase {
    *
    * @group germ_accession_importer
    */
+  #[Group('germ_accession_importer')]
   public function testGermplasmAccessionImporterGetOrganismID() {
 
     // Insert an organism
@@ -190,6 +193,7 @@ class GermplasmAccessionImporterTest extends ChadoTestKernelBase {
    *
    * @group germ_accession_importer
    */
+  #[Group('germ_accession_importer')]
   public function testGermplasmAccessionImporterGetStockID() {
 
     // Insert an organism
@@ -264,6 +268,7 @@ class GermplasmAccessionImporterTest extends ChadoTestKernelBase {
    *
    * @group germ_accession_importer
    */
+  #[Group('germ_accession_importer')]
   public function testGermplasmAccessionImporterGetDbxrefID() {
 
     // Insert an organism
@@ -383,6 +388,7 @@ class GermplasmAccessionImporterTest extends ChadoTestKernelBase {
    *
    * @group germ_accession_importer
    */
+  #[Group('germ_accession_importer')]
   public function testGermplasmAccessionImporterLoadStockProperties() {
     // Insert an organism
     $subtaxa_cvterm_id = $this->getCVtermID('TAXRANK', '0000023');
@@ -498,6 +504,7 @@ class GermplasmAccessionImporterTest extends ChadoTestKernelBase {
    *
    * @group germ_accession_importer
    */
+  #[Group('germ_accession_importer')]
   public function testGermplasmAccessionImporterLoadSynonyms() {
 
     // Insert an organism


### PR DESCRIPTION
**Issue #29**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

Drupal is migrating its plugin discovery mechanism from Annotations to PHP Attributes, particularly Drupal 10.2 and newer versions. This change is in alignment with Symfony and PHP 8 best practices.

Our importer validators currently use Doctrine annotations (eg. @TripalCultivateValidator) for metadata declarations. These should be migrated to PHP 8 attributes to ensure forward compatibility.

## What does this PR do?
<!-- *Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.* -->

Update the following annotations to attributes:
 
- [x] Group
- [x] TripalImporter

## Testing

### Automated Testing
There are no new automated testing for this PR; however, all the automated tests should pass with drupal 11.1.x.
