### PR TITLE
Update PHPUnit workflow to remove PHP 8.4 exclusions

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -34,11 +34,6 @@ jobs:
           - "11.2.x-dev"
           - "11.3.x-dev"
         exclude:
-          # Only Drupal 11.x supports PHP 8.4
-          - php-version: '8.4'
-            drupal-version: '10.5.x-dev'
-          - php-version: '8.4'
-            drupal-version: '10.6.x-dev'
           # Only Drupal 11.3+ supports PHP 8.5.
           - php-version: "8.5"
             drupal-version: "10.5.x-dev"
@@ -53,7 +48,7 @@ jobs:
             drupal-version: "11.3.x-dev"
           # Exclude higher postgresql version from middle Drupal versions
           - pgsql-version: "18"
-            drupal-version: "10.5.x-dev"
+            drupal-version: "10.6.x-dev"
           # Drupal 11+ requires at least php 8.3.
           - php-version: "8.2"
             drupal-version: "11.2.x-dev"


### PR DESCRIPTION
Removed exclusions for PHP 8.4 with Drupal 10.5 and 10.6. We forgot to do this in PR #46.