### PR TITLE
G5.50 Resolve Deprecations

### DIFF
--- a/phpunit.10.xml
+++ b/phpunit.10.xml
@@ -12,7 +12,7 @@
  https://www.drupal.org/node/2116263 for details.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="../../../core/tests/bootstrap.php"
+         bootstrap="../../../modules/contrib/tripal/tripal/tests/tripal-bootstrap.php"
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
@@ -31,6 +31,9 @@
     <ini name="error_reporting" value="32767"/>
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
+    <!-- Defines regular expressions for deprecations in external modules
+      that we want to ignore. Includes those defined by Drupal. -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
     <env name="SIMPLETEST_BASE_URL" value=""/>
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/database_name#table_prefix -->
@@ -73,9 +76,7 @@
     </testsuite>
   </testsuites>
   <!-- Settings for coverage reports. -->
-  <source
-    ignoreSuppressionOfDeprecations="true"
-    >
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory suffix=".php">trpcultivate_germplasm/src</directory>
       <file>trpcultivate_germplasm/trpcultivate_germplasm.module</file>

--- a/phpunit.11.xml
+++ b/phpunit.11.xml
@@ -11,7 +11,7 @@
  https://www.drupal.org/node/2116263 for details.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="../../../core/tests/bootstrap.php"
+         bootstrap="../../../modules/contrib/tripal/tripal/tests/tripal-bootstrap.php"
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
@@ -33,6 +33,9 @@
     <ini name="error_reporting" value="32767"/>
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
+    <!-- Defines regular expressions for deprecations in external modules
+      that we want to ignore. Includes those defined by Drupal. -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt"/>
     <!-- Handling of functional tests. See core/phpunit.xml.dist -->
     <env name="MINK_DRIVER_CLASS" value=""/>
     <env name="MINK_DRIVER_ARGS" value=""/>
@@ -52,10 +55,7 @@
     </testsuite>
   </testsuites>
   <!-- Settings for coverage reports. -->
-  <source
-    ignoreSuppressionOfDeprecations="true"
-    ignoreIndirectDeprecations="true"
-    >
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory suffix=".php">trpcultivate_germplasm/src</directory>
       <file>trpcultivate_germplasm/trpcultivate_germplasm.module</file>

--- a/trpcultivate_germcollection/src/Hook/TripalCultivateGermcollectionHooks.php
+++ b/trpcultivate_germcollection/src/Hook/TripalCultivateGermcollectionHooks.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\trpcultivate_germcollection\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Implements hooks for the Tripal Cultivate Germcollection module.
+ */
+class TripalCultivateGermcollectionHooks {
+
+  use StringTranslationTrait;
+
+  /**
+   * Implements hook_help().
+   */
+  #[Hook('help')]
+  public function help($route_name, RouteMatchInterface $route_match) {
+    switch ($route_name) {
+      // Provides the module overview in the help tab.
+      case 'help.page.trpcultivate_germcollection':
+        $output = '';
+        $output .= '<h3>' . $this->t('About') . '</h3>';
+
+        $output .= '<p>' . $this->t('This module provides support for grouping germplasm into collections and specialized Tripal fields.') . '</p>';
+
+        return $output;
+
+      default:
+    }
+  }
+
+}

--- a/trpcultivate_germcollection/src/Plugin/TripalImporter/GermplasmRelationshipImporter.php
+++ b/trpcultivate_germcollection/src/Plugin/TripalImporter/GermplasmRelationshipImporter.php
@@ -3,11 +3,15 @@
 namespace Drupal\trpcultivate_germcollection\Plugin\TripalImporter;
 
 use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Messenger\Messenger;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\Services\TripalFileRetriever;
+use Drupal\tripal\Services\TripalLogger;
+use Drupal\tripal\TripalBackendPublish\PluginManager\TripalBackendPublishManager;
+use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\Controller\ChadoCVTermAutocompleteController;
 use Drupal\tripal_chado\Controller\ChadoGenericAutocompleteController;
@@ -20,35 +24,8 @@ use Drupal\trpcultivate\Plugin\Validators\ValidHeaders;
 use Drupal\trpcultivate\Service\TripalCultivateFileTemplateService;
 use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
-use Drupal\trpcultivate\TripalImporter\Attribute\TripalImporter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * This is a Germplasm Relationship Importer.
- *
- * @TripalImporter(
- *   id = "trpcultivate-germplasm-relationship-importer",
- *   label = @Translation("Tripal Cultivate: Relate Germplasm"),
- *   description = @Translation("Creates relationships between a single primary accession and related germplasm individuals (both new and existing)."),
- *   file_types = {"tsv", "txt"},
- *   upload_description = @Translation("Please provide a data file."),
- *   upload_title = @Translation("<strong>Related Germplasm*</strong>"),
- *   use_analysis = FALSE,
- *   require_analysis = FALSE,
- *   use_button = True,
- *   submit_disabled = FALSE,
- *   button_text = "Import",
- *   file_upload = TRUE,
- *   file_local = FALSE,
- *   file_remote = FALSE,
- *   file_required = TRUE,
- *   cardinality = 1,
- *   menu_path = "",
- *   callback = "",
- *   callback_module = "",
- *   callback_path = "",
- * )
- */
 #[TripalImporter(
   id: 'trpcultivate-germplasm-relationship-importer',
   label: new TranslatableMarkup('Tripal Cultivate: Relate Germplasm'),
@@ -68,7 +45,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
   cardinality: 1,
   menu_path: '',
   callback: '',
-  callback_module: '',
   callback_path: '',
 )]
 class GermplasmRelationshipImporter extends ChadoImporterBase implements ContainerFactoryPluginInterface {
@@ -85,7 +61,7 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
   /**
    * The Drupal Messenger Service.
    *
-   * @var \Drupal\Core\Messenger\MessengerInterface
+   * @var \Drupal\Core\Messenger\Messenger
    */
   protected $service_Messenger;
 
@@ -194,8 +170,14 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
    *   The entity type manager.
    * @param Drupal\Core\Render\Renderer $renderer
    *   The Drupal renderer service.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   * @param \Drupal\Core\Messenger\Messenger $messenger
    *   The Drupal messenger service.
+   * @param Drupal\tripal\Services\TripalLogger $logger
+   *   Tripal Logger service.
+   * @param Drupal\tripal\Services\TripalFileRetriever $fileretriever
+   *   Tripal File Retriever service.
+   * @param Drupal\tripal\TripalBackendPublish\PluginManager\TripalBackendPublishManager $publish_manager
+   *   Tripal Backend Publish plugin manager.
    */
   public function __construct(
     array $configuration,
@@ -206,9 +188,21 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
     TripalCultivateFileTemplateService $service_FileTemplate,
     EntityTypeManager $service_entityTypeManager,
     Renderer $renderer,
-    MessengerInterface $messenger,
+    Messenger $messenger,
+    TripalLogger $logger,
+    TripalFileRetriever $fileretriever,
+    TripalBackendPublishManager $publish_manager,
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $chado_connection);
+    parent::__construct(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $chado_connection,
+      $messenger,
+      $logger,
+      $fileretriever,
+      $publish_manager,
+    );
 
     $this->service_validatorPluginManager = $service_validatorPluginManager;
     $this->service_FileTemplate = $service_FileTemplate;
@@ -233,6 +227,9 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
       $container->get('entity_type.manager'),
       $container->get('renderer'),
       $container->get('messenger'),
+      $container->get('tripal.logger'),
+      $container->get('tripal.fileretriever'),
+      $container->get('tripal.backend_publish'),
     );
   }
 

--- a/trpcultivate_germcollection/src/Plugin/TripalImporter/GermplasmRelationshipImporter.php
+++ b/trpcultivate_germcollection/src/Plugin/TripalImporter/GermplasmRelationshipImporter.php
@@ -1202,7 +1202,7 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
       ],
     ];
 
-    return $this->service_Renderer->renderPlain($build);
+    return $this->service_Renderer->renderInIsolation($build);
   }
 
 }

--- a/trpcultivate_germcollection/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_germcollection/tests/src/Functional/InstallTest.php
@@ -19,6 +19,11 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 #[RunTestsInSeparateProcesses]
 class InstallTest extends ChadoTestBrowserBase {
 
+  /**
+   * Theme used in the test environment.
+   *
+   * @var string
+   */
   protected $defaultTheme = 'stark';
 
   /**
@@ -30,17 +35,22 @@ class InstallTest extends ChadoTestBrowserBase {
 
   /**
    * The name of your module in the .info.yml.
+   *
+   * @var string
    */
   protected static $module_name = 'Germplasm Collection';
 
   /**
    * The machine name of this module.
+   *
+   * @var string
    */
   protected static $module_machinename = 'trpcultivate_germcollection';
 
   /**
-   * A small excert from your help page.
-   * Do not cross newlines.
+   * A small excert from your help page. Do not cross newlines.
+   *
+   * @var string
    */
   protected static $help_text_excerpt = 'support for grouping germplasm into collections';
 

--- a/trpcultivate_germcollection/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_germcollection/tests/src/Functional/InstallTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Url;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Simple test to ensure that main page loads with module enabled.
@@ -15,6 +16,7 @@ use PHPUnit\Framework\Attributes\Group;
  */
 #[Group('TripalCultivate-Germplasm')]
 #[Group('Installation')]
+#[RunTestsInSeparateProcesses]
 class InstallTest extends ChadoTestBrowserBase {
 
   protected $defaultTheme = 'stark';

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormTest.php
@@ -10,6 +10,7 @@ use Drupal\tripal\Services\TripalLogger;
 use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\tripal_chado\Controller\ChadoCVTermAutocompleteController;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests form + form-related functionality of Germplasm Relationship Importer.
@@ -21,6 +22,7 @@ use Drupal\tripal_chado\Controller\ChadoCVTermAutocompleteController;
 #[Group('tripal-importer')]
 #[Group('chado-importer')]
 #[Group('importer-germrelationship')]
+#[RunTestsInSeparateProcesses]
 class GermplasmRelationshipImporterFormTest extends ChadoTestKernelBase {
 
   use UserCreationTrait;

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormTest.php
@@ -37,6 +37,7 @@ class GermplasmRelationshipImporterFormTest extends ChadoTestKernelBase {
     'system',
     'user',
     'file',
+    'markup',
     'tripal',
     'tripal_chado',
     'tripal_layout',

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormTest.php
@@ -83,7 +83,6 @@ class GermplasmRelationshipImporterFormTest extends ChadoTestKernelBase {
       'cardinality' => 1,
       'menu_path' => '',
       'callback' => '',
-      'callback_module' => '',
       'callback_path' => '',
     ],
   ];

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormTest.php
@@ -37,7 +37,6 @@ class GermplasmRelationshipImporterFormTest extends ChadoTestKernelBase {
     'system',
     'user',
     'file',
-    'markup',
     'tripal',
     'tripal_chado',
     'tripal_layout',

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormValidateTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormValidateTest.php
@@ -11,6 +11,7 @@ use Drupal\tripal\Services\TripalLogger;
 use Drupal\Core\Form\FormState;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Drupal\tripal_chado\Controller\ChadoCVTermAutocompleteController;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests formValidate() functionality of the Germplasm Relationship Importer.
@@ -22,6 +23,7 @@ use Drupal\tripal_chado\Controller\ChadoCVTermAutocompleteController;
 #[Group('tripal-importer')]
 #[Group('chado-importer')]
 #[Group('importer-germrelationship')]
+#[RunTestsInSeparateProcesses]
 class GermplasmRelationshipImporterFormValidateTest extends ChadoTestKernelBase {
 
   use UserCreationTrait;

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormValidateTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormValidateTest.php
@@ -38,6 +38,7 @@ class GermplasmRelationshipImporterFormValidateTest extends ChadoTestKernelBase 
     'system',
     'user',
     'file',
+    'markup',
     'tripal',
     'tripal_chado',
     'tripal_layout',

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormValidateTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormValidateTest.php
@@ -84,7 +84,6 @@ class GermplasmRelationshipImporterFormValidateTest extends ChadoTestKernelBase 
       'cardinality' => 1,
       'menu_path' => '',
       'callback' => '',
-      'callback_module' => '',
       'callback_path' => '',
     ],
   ];

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormValidateTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterFormValidateTest.php
@@ -38,7 +38,6 @@ class GermplasmRelationshipImporterFormValidateTest extends ChadoTestKernelBase 
     'system',
     'user',
     'file',
-    'markup',
     'tripal',
     'tripal_chado',
     'tripal_layout',

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterRunTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterRunTest.php
@@ -11,6 +11,7 @@ use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Controller\ChadoGenericAutocompleteController;
 use Drupal\tripal_chado\Controller\ChadoCVTermAutocompleteController;
 use Drupal\trpcultivate_germcollection\Plugin\TripalImporter\GermplasmRelationshipImporter;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests functionality of the run() method of Germplasm Relationship Importer.
@@ -18,6 +19,7 @@ use Drupal\trpcultivate_germcollection\Plugin\TripalImporter\GermplasmRelationsh
  * @group relationshipImporter
  */
 #[Group('relationshipImporter')]
+#[RunTestsInSeparateProcesses]
 class GermplasmRelationshipImporterRunTest extends ChadoTestKernelBase {
 
   use UserCreationTrait;

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterRunTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterRunTest.php
@@ -80,7 +80,6 @@ class GermplasmRelationshipImporterRunTest extends ChadoTestKernelBase {
       'cardinality' => 1,
       'menu_path' => '',
       'callback' => '',
-      'callback_module' => '',
       'callback_path' => '',
     ],
   ];
@@ -167,6 +166,9 @@ class GermplasmRelationshipImporterRunTest extends ChadoTestKernelBase {
       $container->get('entity_type.manager'),
       $container->get('renderer'),
       $container->get('messenger'),
+      $container->get('tripal.logger'),
+      $container->get('tripal.fileretriever'),
+      $container->get('tripal.backend_publish'),
     );
 
     $this->module_path = $this->container->get('module_handler')

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterRunTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterRunTest.php
@@ -34,7 +34,6 @@ class GermplasmRelationshipImporterRunTest extends ChadoTestKernelBase {
     'system',
     'user',
     'file',
-    'markup',
     'tripal',
     'tripal_chado',
     'tripal_layout',

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterRunTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterRunTest.php
@@ -34,6 +34,7 @@ class GermplasmRelationshipImporterRunTest extends ChadoTestKernelBase {
     'system',
     'user',
     'file',
+    'markup',
     'tripal',
     'tripal_chado',
     'tripal_layout',

--- a/trpcultivate_germcollection/trpcultivate_germcollection.module
+++ b/trpcultivate_germcollection/trpcultivate_germcollection.module
@@ -5,22 +5,17 @@
  * Contains all hook implementations for this module.
  */
 
+use Drupal\Core\Hook\Attribute\LegacyHook;
 use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Implements hook_help().
+ *
+ * This legacy hook is only run for Drupal < 11, and is replaced by class
+ * Drupal\trpcultivate_germcollection\Hook\TripalCultivateGermcollectionHooks in
+ * trpcultivate_germcollection/src/Hook/TripalCultivateGermcollectionHooks.php.
  */
+#[LegacyHook]
 function trpcultivate_germcollection_help($route_name, RouteMatchInterface $route_match) {
-  switch ($route_name) {
-    // Provides the module overview in the help tab.
-    case 'help.page.trpcultivate_germcollection':
-      $output = '';
-      $output .= '<h3>' . t('About') . '</h3>';
-
-      $output .= '<p>' . t('This module provides support for grouping germplasm into collections and specialized Tripal fields.') . '</p>';
-
-      return $output;
-
-    default:
-  }
+  return \Drupal::service('trpcultivate_germcollection.hooks')->help($route_name, $route_match);
 }

--- a/trpcultivate_germcollection/trpcultivate_germcollection.services.yml
+++ b/trpcultivate_germcollection/trpcultivate_germcollection.services.yml
@@ -1,0 +1,3 @@
+services:
+  trpcultivate_germcollection.hooks:
+    class: 'Drupal\trpcultivate_germcollection\Hook\TripalCultivateGermcollectionHooks'

--- a/trpcultivate_germplasm/src/Hook/TripalCultivateGermplasmHooks.php
+++ b/trpcultivate_germplasm/src/Hook/TripalCultivateGermplasmHooks.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\trpcultivate_germplasm\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Implements hooks for the Tripal Cultivate Germplasm module.
+ */
+class TripalCultivateGermplasmHooks {
+
+  use StringTranslationTrait;
+
+  /**
+   * Implements hook_help().
+   */
+  #[Hook('help')]
+  public function help($route_name, RouteMatchInterface $route_match) {
+    switch ($route_name) {
+      // Provides the module overview in the help tab.
+      case 'help.page.trpcultivate_germplasm':
+        $output = '';
+        $output .= '<h3>' . $this->t('About') . '</h3>';
+        $output .= '<p>' . $this->t('This module provides specialized Tripal fields and importers for germplasm.') . '</p>';
+
+        return $output;
+
+      default:
+    }
+  }
+
+}

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmAccessionImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmAccessionImporter.php
@@ -7,28 +7,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Messenger\Messenger;
+use Drupal\tripal\Services\TripalFileRetriever;
+use Drupal\tripal\Services\TripalLogger;
+use Drupal\tripal\TripalBackendPublish\PluginManager\TripalBackendPublishManager;
 use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
 
-/**
- * Provides an importer for loading germplasm accessions from a tab-delimited
- * file.
- *
- * @TripalImporter(
- *   id = "trpcultivate-germplasm-accession",
- *   label = @Translation("Tripal Cultivate: Germplasm Accessions"),
- *   description = @Translation("Imports germplasm accessions into Chado with metadata meeting BrAPI standards."),
- *   file_types = {"tsv", "txt"},
- *   use_analysis = FALSE,
- *   require_analysis = FALSE,
- *   upload_title = "Germplasm Accession Import",
- *   button_text = "Import Germplasm Accessions",
- *   file_upload = True,
- *   file_load = True,
- *   file_remote = True,
- *   file_required = True,
- *   cardinality = 1
- * )
- */
+
 #[TripalImporter(
    id: 'trpcultivate-germplasm-accession',
    label: new TranslatableMarkup('Tripal Cultivate: Germplasm Accessions'),
@@ -98,7 +83,11 @@ class GermplasmAccessionImporter extends ChadoImporterBase {
       $plugin_id,
       $plugin_definition,
       $container->get('tripal_chado.database'),
-      $container->get('config.factory')
+      $container->get('config.factory'),
+      $container->get('messenger'),
+      $container->get('tripal.logger'),
+      $container->get('tripal.fileretriever'),
+      $container->get('tripal.backend_publish'),
     );
   }
 
@@ -119,8 +108,27 @@ class GermplasmAccessionImporter extends ChadoImporterBase {
    * @param Drupal\tripal_chado\Database\ChadoConnection $connection
    * @param
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ChadoConnection $connection, ConfigFactoryInterface $config_factory) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $connection);
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    ChadoConnection $connection,
+    ConfigFactoryInterface $config_factory,
+    Messenger $messenger,
+    TripalLogger $logger,
+    TripalFileRetriever $fileretriever,
+    TripalBackendPublishManager $publish_manager,
+  ) {
+    parent::__construct(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $connection,
+      $messenger,
+      $logger,
+      $fileretriever,
+      $publish_manager,
+    );
 
     $this->config_factory = $config_factory;
   }

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmAccessionImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmAccessionImporter.php
@@ -254,8 +254,8 @@ class GermplasmAccessionImporter extends ChadoImporterBase {
     $germplasm_config = $this->config_factory->get('trpcultivate_germplasm.settings');
     // Iterate through our cvterms
     // If it hasn't been set before, set it now
-    foreach($this->cvterms as $term){
-      if (!isset($this->cvterms[$term])){
+    foreach ($this->cvterms as $term => $value) {
+      if (!isset($value)) {
         $terms_string = 'terms.' . $term;
         $this->setCVterm($term, $germplasm_config->get($terms_string));
       }

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -3,11 +3,14 @@
 namespace Drupal\trpcultivate_germplasm\Plugin\TripalImporter;
 
 use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Messenger\Messenger;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\Services\TripalFileRetriever;
+use Drupal\tripal\Services\TripalLogger;
+use Drupal\tripal\TripalBackendPublish\PluginManager\TripalBackendPublishManager;
 use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
 use Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager;
 use Drupal\tripal_chado\Controller\ChadoOrganismFormElementController;
@@ -26,34 +29,6 @@ use Drupal\trpcultivate\Service\TripalCultivateFileTemplateService;
 use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * Tripal Cultivate Germplasm - Cross Importer.
- *
- * An importer for germplasm crosses developed in a breeding program.
- *
- * @TripalImporter(
- *   id = "trpcultivate-germplasm-cross-importer",
- *   label = @Translation("Tripal Cultivate: Germplasm Cross Importer"),
- *   description = @Translation("Creates germplasm cross pages associated with parental material through upload of a germplasm cross data file."),
- *   file_types = {"tsv"},
- *   upload_description = @Translation("Please provide a data file."),
- *   upload_title = @Translation("Germplasm Cross Data File*"),
- *   use_analysis = FALSE,
- *   require_analysis = FALSE,
- *   use_button = True,
- *   submit_disabled = FALSE,
- *   button_text = "Import",
- *   file_upload = TRUE,
- *   file_local = FALSE,
- *   file_remote = FALSE,
- *   file_required = TRUE,
- *   cardinality = 1,
- *   menu_path = "",
- *   callback = "",
- *   callback_module = "",
- *   callback_path = "",
- * )
- */
 #[TripalImporter(
    id: 'trpcultivate-germplasm-cross-importer',
    label: new TranslatableMarkup('Tripal Cultivate: Germplasm Cross Importer'),
@@ -205,9 +180,9 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
   /**
    * The Drupal Messenger Service.
    *
-   * @var \Drupal\Core\Messenger\MessengerInterface
+   * @var \Drupal\Core\Messenger\Messenger
    */
-  protected MessengerInterface $service_Messenger;
+  protected Messenger $service_Messenger;
 
   /**
    * Used to reference the validation result summary in the form.
@@ -256,7 +231,7 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
    *   The entity type manager.
    * @param Drupal\Core\Render\Renderer $renderer
    *   The Drupal renderer service.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   * @param \Drupal\Core\Messenger\Messenger $messenger
    *   The Drupal messenger service.
    */
   public function __construct(
@@ -269,9 +244,21 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
     TripalCultivateFileTemplateService $service_FileTemplate,
     EntityTypeManager $service_entityTypeManager,
     Renderer $renderer,
-    MessengerInterface $messenger,
+    Messenger $messenger,
+    TripalLogger $logger,
+    TripalFileRetriever $fileretriever,
+    TripalBackendPublishManager $publish_manager,
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $chado_connection);
+    parent::__construct(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $chado_connection,
+      $messenger,
+      $logger,
+      $fileretriever,
+      $publish_manager,
+    );
     $this->chado_connection = $chado_connection;
     $this->buddy_manager = $buddy_manager;
     $this->cvterm_buddy = $this->buddy_manager->createInstance('chado_cvterm_buddy', []);
@@ -299,6 +286,9 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       $container->get('entity_type.manager'),
       $container->get('renderer'),
       $container->get('messenger'),
+      $container->get('tripal.logger'),
+      $container->get('tripal.fileretriever'),
+      $container->get('tripal.backend_publish'),
     );
   }
 

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -963,7 +963,7 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       ],
     ];
 
-    return $this->service_Renderer->renderPlain($build);
+    return $this->service_Renderer->renderInIsolation($build);
   }
 
   /**

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -17,6 +17,7 @@ use Drupal\tripal_chado\Controller\ChadoOrganismFormElementController;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoCvtermBuddy;
 use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoPropertyBuddy;
+use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoOrganismBuddy;
 use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Drupal\trpcultivate\Plugin\Validators\ValidDataFile;
 use Drupal\trpcultivate\Plugin\Validators\EmptyCell;
@@ -150,6 +151,13 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
   protected ChadoPropertyBuddy $property_buddy;
 
   /**
+   * An instance of the organism Chado Buddy.
+   *
+   * @var Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoOrganismBuddy
+   */
+  protected ChadoOrganismBuddy $organism_buddy;
+
+  /**
    * The TripalCultivate validator plugin manager.
    *
    * @var \Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
@@ -263,6 +271,7 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
     $this->buddy_manager = $buddy_manager;
     $this->cvterm_buddy = $this->buddy_manager->createInstance('chado_cvterm_buddy', []);
     $this->property_buddy = $this->buddy_manager->createInstance('chado_property_buddy', []);
+    $this->organism_buddy = $this->buddy_manager->createInstance('chado_organism_buddy', []);
     $this->service_validatorPluginManager = $service_validatorPluginManager;
     $this->service_entityTypeManager = $service_entityTypeManager;
     $this->service_FileTemplate = $service_FileTemplate;
@@ -980,7 +989,7 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
    */
   public function getGenusFromOrgId(int $organism_id) {
     // Lookup the organism ID and make sure its valid.
-    $organism_obj = chado_get_organism(['organism_id' => $organism_id]);
+    $organism_obj = $this->organism_buddy->getOrganism(['organism.organism_id' => $organism_id]);
     if ($organism_obj == NULL) {
       $error_message = "The organism ID $organism_id is not valid.";
       $this->logger->error($error_message);
@@ -988,7 +997,7 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
     }
 
     // Return just the genus.
-    return $organism_obj->genus;
+    return $organism_obj[0]->getValue('organism.genus');
   }
 
 }

--- a/trpcultivate_germplasm/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_germplasm/tests/src/Functional/InstallTest.php
@@ -8,6 +8,7 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
 use Drupal\Tests\trpcultivate_germplasm\Traits\TripalMviewQueriesTestTrait;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests to ensure that the module is enabled and terms are installed.
@@ -17,6 +18,7 @@ use PHPUnit\Framework\Attributes\Group;
  */
 #[Group('TripalCultivate-Germplasm')]
 #[Group('Installation')]
+#[RunTestsInSeparateProcesses]
 class InstallTest extends ChadoTestBrowserBase {
 
   /**

--- a/trpcultivate_germplasm/tests/src/Kernel/GermplasmTermInstallTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/GermplasmTermInstallTest.php
@@ -6,6 +6,8 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_germplasm\Traits\TripalMviewQueriesTestTrait;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests terms added by trpcultivate_germplasm_install_terms() during install.
@@ -15,6 +17,7 @@ use Drupal\user\Entity\User;
  */
 #[Group('TripalCultivate-Germplasm')]
 #[Group('Installation')]
+#[RunTestsInSeparateProcesses]
 class GermplasmTermInstallTest extends ChadoTestKernelBase {
 
   /**

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterRunTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterRunTest.php
@@ -102,7 +102,11 @@ class GermplasmAccessionImporterRunTest extends ChadoTestKernelBase {
       'trpcultivate-germplasm-accession',
       $this->definitions,
       $this->connection,
-      $this->config_factory
+      $this->config_factory,
+      $container->get('messenger'),
+      $container->get('tripal.logger'),
+      $container->get('tripal.fileretriever'),
+      $container->get('tripal.backend_publish'),
     );
 
     $subtaxa_cvterm_id = $this->getCVtermID('TAXRANK', '0000023');

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterRunTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterRunTest.php
@@ -7,10 +7,12 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\Tests\trpcultivate_germplasm\Traits\GermplasmAccessionImporterTestTrait;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the functionality of the Germplasm Accession Importer.
  */
+#[RunTestsInSeparateProcesses]
 class GermplasmAccessionImporterRunTest extends ChadoTestKernelBase {
 
 	protected $defaultTheme = 'stark';

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterTest.php
@@ -90,7 +90,11 @@ class GermplasmAccessionImporterTest extends ChadoTestKernelBase {
       'trpcultivate-germplasm-accession',
       $this->definitions,
       $this->connection,
-      $this->config_factory
+      $this->config_factory,
+      $container->get('messenger'),
+      $container->get('tripal.logger'),
+      $container->get('tripal.fileretriever'),
+      $container->get('tripal.backend_publish'),
     );
 
     $subtaxa_cvterm_id = $this->getCVtermID('TAXRANK', '0000023');

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterTest.php
@@ -6,10 +6,12 @@ use Drupal\Core\Url;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_germplasm\Traits\GermplasmAccessionImporterTestTrait;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the functionality of the Germplasm Accession Importer.
  */
+#[RunTestsInSeparateProcesses]
 class GermplasmAccessionImporterTest extends ChadoTestKernelBase {
 
 	protected $defaultTheme = 'stark';

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -42,6 +42,7 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     'system',
     'user',
     'file',
+    'markup',
     'tripal',
     'tripal_chado',
     'tripal_layout',

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -42,7 +42,6 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     'system',
     'user',
     'file',
-    'markup',
     'tripal',
     'tripal_chado',
     'tripal_layout',

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -10,6 +10,7 @@ use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the form + form-related functionality of the Germplasm Cross Importer.
@@ -19,6 +20,7 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('tripal-importer')]
 #[Group('chado-importer')]
 #[Group('importer-germplasmcross')]
+#[RunTestsInSeparateProcesses]
 class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
 
   use UserCreationTrait;

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
@@ -42,7 +42,6 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     'system',
     'user',
     'file',
-    'markup',
     'tripal',
     'tripal_chado',
     'tripal_layout',

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
@@ -42,6 +42,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     'system',
     'user',
     'file',
+    'markup',
     'tripal',
     'tripal_chado',
     'tripal_layout',

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
@@ -10,6 +10,7 @@ use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the formValidate() functionality of the Cross Importer.
@@ -19,6 +20,7 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('tripal-importer')]
 #[Group('chado-importer')]
 #[Group('importer-germplasmcross')]
+#[RunTestsInSeparateProcesses]
 class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
 
   use UserCreationTrait;

--- a/trpcultivate_germplasm/trpcultivate_germplasm.module
+++ b/trpcultivate_germplasm/trpcultivate_germplasm.module
@@ -5,23 +5,19 @@
  * Contains all hook implementations for this module.
  */
 
+use Drupal\Core\Hook\Attribute\LegacyHook;
 use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Implements hook_help().
+ *
+ * This legacy hook is only run for Drupal < 11, and is replaced by class
+ * Drupal\trpcultivate_germplasm\Hook\TripalCultivateGermplasmHooks in
+ * trpcultivate_germplasm/src/Hook/TripalCultivateGermplasmHooks.php.
  */
+#[LegacyHook]
 function trpcultivate_germplasm_help($route_name, RouteMatchInterface $route_match) {
-  switch ($route_name) {
-    // Provides the module overview in the help tab.
-    case 'help.page.trpcultivate_germplasm':
-      $output = '';
-      $output .= '<h3>' . t('About') . '</h3>';
-      $output .= '<p>' . t('This module provides specialized Tripal fields and importers for germplasm.') . '</p>';
-
-      return $output;
-
-    default:
-  }
+  return \Drupal::service('trpcultivate_germplasm.hooks')->help($route_name, $route_match);
 }
 
 /**

--- a/trpcultivate_germplasm/trpcultivate_germplasm.services.yml
+++ b/trpcultivate_germplasm/trpcultivate_germplasm.services.yml
@@ -1,0 +1,3 @@
+services:
+  trpcultivate_germplasm.hooks:
+    class: 'Drupal\trpcultivate_germplasm\Hook\TripalCultivateGermplasmHooks'


### PR DESCRIPTION
**Issue #50**

## Motivation
This PR addresses deprecations mentioned in issue #50 

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?

Addresses the following deprecations: 
- [x] Using null as an array offset is deprecated, use an empty string instead
- [x] Functional/FunctionalJavascript test classes must specify the #[RunTestsInSeparateProcesses] attribute, not doing so is deprecated in drupal:11.3.0 and is throwing an exception in drupal:12.0.0. See https://www.drupal.org/node/3548485
- [x] Kernel test classes must specify the #[RunTestsInSeparateProcesses] attribute, not doing so is deprecated in drupal:11.3.0 and will throw an exception in drupal:12.0.0. See https://www.drupal.org/node/3548485
- [x] Using @TripalImporter annotation for plugin with ID trpcultivate-germplasm-relationship-importer is deprecated and is removed from drupal:13.0.0. Use a Drupal\tripal\TripalImporter\Attribute\TripalImporter attribute instead. See https://www.drupal.org/node/3395575
- [x] Renderer::renderPlain() is deprecated in drupal:10.3.0 and is removed from drupal:12.0.0. Instead, you should use ::renderInIsolation(). See https://www.drupal.org/node/3407994

#### External Deprecations
- [x] devel_requirements without a #[LegacyRequirementsHook] attribute is deprecated in drupal:11.3.0 and removed in drupal:13.0.0. See https://www.drupal.org/node/3549685
- [x] field_group_module_implements_alter without a #[LegacyModuleImplementsAlter] attribute is deprecated in drupal:11.2.0 and removed in drupal:12.0.0. See https://www.drupal.org/node/3496788
- [x] gin_toolbar_requirements without a #[LegacyRequirementsHook] attribute is deprecated in drupal:11.3.0 and removed in drupal:13.0.0. See https://www.drupal.org/node/3549685
- [x] gin_toolbar_requirements_alter without a #[LegacyRequirementsHook] attribute is deprecated in drupal:11.3.0 and removed in drupal:13.0.0. See https://www.drupal.org/node/3549685
- [x] Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Drupal\devel\Twig\Extension\Debug" now to avoid errors or add an explicit @return annotation to suppress this message.

#### Field Annotation vs Attribute deprecations

- [x] Not supporting attribute discovery in Drupal\field_group\FieldGroupFormatterPluginManager is deprecated in drupal:11.2.0 and is removed from drupal:12.0.0. Provide an Attribute class and an Annotation class for BC. See https://www.drupal.org/node/3395582
- [x] Using @FieldType annotation for plugin with ID markup is deprecated and is removed from drupal:13.0.0. Use a Drupal\Core\Field\Attribute\FieldType attribute instead. See https://www.drupal.org/node/3395575
- [x] Using @FieldFormatter annotation for plugin with ID markup is deprecated and is removed from drupal:13.0.0. Use a Drupal\Core\Field\Attribute\FieldFormatter attribute instead. See https://www.drupal.org/node/3395575

#### Theme deprecations

- [x] Providing a file for theme hook horizontal_tabs is deprecated in drupal:11.3.0 and is removed from drupal:12.0.0. Use initial preprocess for template_preprocess instead. See https://www.drupal.org/node/3549500
- [x] Providing template_preprocess_horizontal_tabs() is deprecated in drupal:11.3.0 and is removed from drupal:12.0.0. Use initial preprocess for template_preprocess instead. See https://www.drupal.org/node/3504125
- [x] Providing a file for theme hook field_group_html_element is deprecated in drupal:11.3.0 and is removed from drupal:12.0.0. Use initial preprocess for template_preprocess instead. See https://www.drupal.org/node/3549500
- [x] Providing template_preprocess_field_group_html_element() is deprecated in drupal:11.3.0 and is removed from drupal:12.0.0. Use initial preprocess for template_preprocess instead. See https://www.drupal.org/node/3504125

#### Tripal related deprecations

- [x] Calling Drupal\tripal\TripalImporter\TripalImporterBase::__construct() without the $messenger argument is deprecated in tripal 4.0.0-alpha3 and it will be required in tripal:4.1.0. To resolve this, make sure the create() method in your importer grabs the Drupal\Core\Messenger\Messenger from the container and supplies it to the parent in the constructor. See https://tripaldoc.readthedocs.io/en/latest/dev_guide/deprecations/tripalimporter_dev_inj_constructor.html
- [x] Calling Drupal\tripal\TripalImporter\TripalImporterBase::__construct() without the $logger argument is deprecated in tripal 4.0.0-alpha3 and it will be required in tripal:4.1.0. To resolve this, make sure the create() method in your importer grabs the Drupal\tripal\Services\TripalLogger from the container and supplies it to the parent in the constructor. See https://tripaldoc.readthedocs.io/en/latest/dev_guide/deprecations/tripalimporter_dev_inj_constructor.html
- [x] Calling Drupal\tripal\TripalImporter\TripalImporterBase::__construct() without the $fileretriever argument is deprecated in tripal 4.0.0-alpha3 and it will be required in tripal:4.1.0. To resolve this, make sure the create() method in your importer grabs the Drupal\tripal\Services\TripalFileRetriever from the container and supplies it to the parent in the constructor. See https://tripaldoc.readthedocs.io/en/latest/dev_guide/deprecations/tripalimporter_dev_inj_constructor.html
- [x] Calling Drupal\tripal\TripalImporter\TripalImporterBase::__construct() without the $publish_manager argument is deprecated in tripal 4.0.0-alpha3 and it will be required in tripal:4.1.0. To resolve this, make sure the create() method in your importer grabs the Drupal\tripal\TripalBackendPublish\PluginManager\TripalBackendPublishManager from the container and supplies it to the parent in the constructor. See https://tripaldoc.readthedocs.io/en/latest/dev_guide/deprecations/tripalimporter_dev_inj_constructor.html
- [x] chado_select_record() deprecated in tripal:4.0.0-alpha3 and is removed from tripal:4.1.0. Use the Tripal DBX query API instead. See https://tripaldoc.readthedocs.io/en/latest/dev_guide/deprecations/chado_query_api.html
- [x] chado_select_record_check_value_type() deprecated in tripal:4.0.0-alpha3 and is removed from tripal:4.1.0. Use the Tripal DBX query API instead. See https://tripaldoc.readthedocs.io/en/latest/dev_guide/deprecations/chado_query_api.html

#### Legacy Hooks
Updated the following legacy hooks with OOP methods:

trpcultivate_germcollection
- [x] hook_help()

trpcultivate_germplasm
- [x] hook_help()

## Testing

1. Start a fresh docker on the g5.50-resolveDeprecations branch
2. Run the `phpunit` tests.
3. Ensure there are no deprecations related to those marked as completed above.