### PR TITLE
Switch to stable version of Drupal except for 11.x-dev

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -29,31 +29,31 @@ jobs:
           - "14"
           - "18"
         drupal-version:
-          - "10.5.x-dev"
-          - "10.6.x-dev"
-          - "11.2.x-dev"
-          - "11.3.x-dev"
+          - "10.5.x"
+          - "10.6.x"
+          - "11.2.x"
+          - "11.3.x"
         exclude:
           # Only Drupal 11.3+ supports PHP 8.5.
           - php-version: "8.5"
-            drupal-version: "10.5.x-dev"
+            drupal-version: "10.5.x"
           - php-version: "8.5"
-            drupal-version: "10.6.x-dev"
+            drupal-version: "10.6.x"
           - php-version: "8.5"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           # Drupal 11+ requires at least Postgresql 16.
           - pgsql-version: "14"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           - pgsql-version: "14"
-            drupal-version: "11.3.x-dev"
+            drupal-version: "11.3.x"
           # Exclude higher postgresql version from middle Drupal versions
           - pgsql-version: "18"
-            drupal-version: "10.6.x-dev"
+            drupal-version: "10.6.x"
           # Drupal 11+ requires at least php 8.3.
           - php-version: "8.2"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           - php-version: "8.2"
-            drupal-version: "11.3.x-dev"
+            drupal-version: "11.3.x"
 
     steps:
       # Check out the repo

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -7,7 +7,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   run-coverage:
-    name: "Drupal 11.3.x-dev - PHP 8.5 - PostgreSQL 18"
+    name: "Drupal 11.3.x - PHP 8.5 - PostgreSQL 18"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -21,5 +21,5 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.5
           pgsql-version: 18
-          drupal-version: 11.3.x-dev
+          drupal-version: 11.3.x
           qltycloud-reporter-id: ${{ secrets.QLTY_COVERAGE_TOKEN }}

--- a/.github/workflows/MAIN-buildDocker.yml.yml
+++ b/.github/workflows/MAIN-buildDocker.yml.yml
@@ -31,39 +31,39 @@ jobs:
           - "17"
           - "18"
         drupal-version:
-          - "10.5.x-dev"
-          - "10.6.x-dev"
+          - "10.5.x"
+          - "10.6.x"
           - "11.x-dev"
-          - "11.2.x-dev"
-          - "11.3.x-dev"
+          - "11.2.x"
+          - "11.3.x"
         exclude:
           # Only Drupal 11.3+ supports PHP 8.5.
           - php-version: "8.5"
-            drupal-version: "10.5.x-dev"
+            drupal-version: "10.5.x"
           - php-version: "8.5"
-            drupal-version: "10.6.x-dev"
+            drupal-version: "10.6.x"
           - php-version: "8.5"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           # Drupal 11.x requires PHP 8.3+.
           - php-version: "8.2"
             drupal-version: "11.x-dev"
           - php-version: "8.2"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           - php-version: "8.2"
-            drupal-version: "11.3.x-dev"
+            drupal-version: "11.3.x"
           # Drupal 11+ requires at least Postgresql 16.
           - pgsql-version: "14"
             drupal-version: "11.x-dev"
           - pgsql-version: "15"
             drupal-version: "11.x-dev"
           - pgsql-version: "14"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           - pgsql-version: "15"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           - pgsql-version: "14"
-            drupal-version: "11.3.x-dev"
+            drupal-version: "11.3.x"
           - pgsql-version: "15"
-            drupal-version: "11.3.x-dev"
+            drupal-version: "11.3.x"
     name: TripalCultivate ${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
     steps:
       - uses: actions/checkout@v6
@@ -89,8 +89,8 @@ jobs:
           buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }},postgresqlversion=${{ matrix.pgsql-version }},installTheme='notheme-'"
           labels: 'drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v6.5
-        name: Build baseonly-latest using 11.3.x-dev, PHP 8.5, PgSQL 18
-        if: ${{ matrix.drupal-version == '11.3.x-dev' && matrix.php-version == '8.5' && matrix.pgsql-version == '18' }}
+        name: Build baseonly-latest using 11.3.x, PHP 8.5, PgSQL 18
+        if: ${{ matrix.drupal-version == '11.3.x' && matrix.php-version == '8.5' && matrix.pgsql-version == '18' }}
         with:
           image: knowpulse/tripalcultivate-base
           tags: latest

--- a/.github/workflows/MAIN-buildTripalDocker.yml
+++ b/.github/workflows/MAIN-buildTripalDocker.yml
@@ -28,39 +28,39 @@ jobs:
           - "17"
           - "18"
         drupal-version:
-          - "10.5.x-dev"
-          - "10.6.x-dev"
+          - "10.5.x"
+          - "10.6.x"
           - "11.x-dev"
-          - "11.2.x-dev"
-          - "11.3.x-dev"
+          - "11.2.x"
+          - "11.3.x"
         exclude:
           ## Only Drupal 11.3+ supports PHP 8.5.
           - php-version: "8.5"
-            drupal-version: "10.5.x-dev"
+            drupal-version: "10.5.x"
           - php-version: "8.5"
-            drupal-version: "10.6.x-dev"
+            drupal-version: "10.6.x"
           - php-version: "8.5"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           ## Drupal 11.x requires PHP 8.3+.
           - php-version: "8.2"
             drupal-version: "11.x-dev"
           - php-version: "8.2"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           - php-version: "8.2"
-            drupal-version: "11.3.x-dev"
+            drupal-version: "11.3.x"
           # Drupal 11+ requires at least Postgresql 16.
           - pgsql-version: "14"
             drupal-version: "11.x-dev"
           - pgsql-version: "15"
             drupal-version: "11.x-dev"
           - pgsql-version: "14"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           - pgsql-version: "15"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.2.x"
           - pgsql-version: "14"
-            drupal-version: "11.3.x-dev"
+            drupal-version: "11.3.x"
           - pgsql-version: "15"
-            drupal-version: "11.3.x-dev"
+            drupal-version: "11.3.x"
     name: Tripal ${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
     steps:
       - uses: actions/checkout@v6
@@ -88,8 +88,8 @@ jobs:
           buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }},postgresqlversion=${{ matrix.pgsql-version }},installTheme=FALSE"
           labels: 'drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}", tripal.version="4.x", theme="Olivero"'
       - uses: mr-smithers-excellent/docker-build-push@v6.3
-        name: Build latest using 11.3.x-dev, PHP 8.5, PgSQL 18
-        if: ${{ matrix.drupal-version == '11.3.x-dev' && matrix.php-version == '8.5' && matrix.pgsql-version == '18' }}
+        name: Build latest using 11.3.x, PHP 8.5, PgSQL 18
+        if: ${{ matrix.drupal-version == '11.3.x' && matrix.php-version == '8.5' && matrix.pgsql-version == '18' }}
         with:
           image: knowpulse/tripalcultivate-tripal
           tags: latest

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_5x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.2 - Drupal 10.5.x-dev - PostgreSQL 18'
+    name: 'PHP 8.2 - Drupal 10.5.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.2'
-          drupal-version: '10.5.x-dev'
+          drupal-version: '10.5.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_6x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_6x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.2 - Drupal 10.6.x-dev - PostgreSQL 18'
+    name: 'PHP 8.2 - Drupal 10.6.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.2'
-          drupal-version: '10.6.x-dev'
+          drupal-version: '10.6.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.3_D10_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D10_5x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.3 - Drupal 10.5.x-dev - PostgreSQL 18'
+    name: 'PHP 8.3 - Drupal 10.5.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.3'
-          drupal-version: '10.5.x-dev'
+          drupal-version: '10.5.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.3_D10_6x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D10_6x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.3 - Drupal 10.6.x-dev - PostgreSQL 18'
+    name: 'PHP 8.3 - Drupal 10.6.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.3'
-          drupal-version: '10.6.x-dev'
+          drupal-version: '10.6.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.3_D11_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D11_2x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.3 - Drupal 11.2.x-dev - PostgreSQL 18'
+    name: 'PHP 8.3 - Drupal 11.2.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.3'
-          drupal-version: '11.2.x-dev'
+          drupal-version: '11.2.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.3_D11_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D11_3x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.3 - Drupal 11.3.x-dev - PostgreSQL 18'
+    name: 'PHP 8.3 - Drupal 11.3.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.3'
-          drupal-version: '11.3.x-dev'
+          drupal-version: '11.3.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.4_D10_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.4_D10_5x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.4 - Drupal 10.5.x-dev - PostgreSQL 18'
+    name: 'PHP 8.4 - Drupal 10.5.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.4'
-          drupal-version: '10.5.x-dev'
+          drupal-version: '10.5.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.4_D10_6x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.4_D10_6x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.4 - Drupal 10.6.x-dev - PostgreSQL 18'
+    name: 'PHP 8.4 - Drupal 10.6.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.4'
-          drupal-version: '10.6.x-dev'
+          drupal-version: '10.6.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.4_D11_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.4_D11_2x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.4 - Drupal 11.2.x-dev - PostgreSQL 18'
+    name: 'PHP 8.4 - Drupal 11.2.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.4'
-          drupal-version: '11.2.x-dev'
+          drupal-version: '11.2.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.4_D11_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.4_D11_3x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.4 - Drupal 11.3.x-dev - PostgreSQL 18'
+    name: 'PHP 8.4 - Drupal 11.3.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.4'
-          drupal-version: '11.3.x-dev'
+          drupal-version: '11.3.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.5_D11_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.5_D11_3x.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.5 - Drupal 11.3.x-dev - PostgreSQL 18'
+    name: 'PHP 8.5 - Drupal 11.3.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'trpcultivate_germplasm'
           modules: 'trpcultivate_germplasm, trpcultivate_germcollection'
           php-version: '8.5'
-          drupal-version: '11.3.x-dev'
+          drupal-version: '11.3.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG drupalversion=11.3.x-dev
+ARG drupalversion=11.x
 ARG phpversion=8.5
 ARG postgresqlversion=18
 ARG buildplatform='linux/amd64'

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-| PHP\Drupal | 10.5.x-dev          | 10.6.x-dev          | 11.2.x-dev          | 11.3.x-dev          |
+| PHP\Drupal | 10.5.x          | 10.6.x          | 11.2.x          | 11.3.x          |
 |------------|---------------------|---------------------|---------------------|---------------------|
 | **PHP8.2** | ![Grid82-105-Badge] | ![Grid82-106-Badge] |                     |                     |
 | **PHP8.3** | ![Grid83-105-Badge] | ![Grid83-106-Badge] | ![Grid83-112-Badge] | ![Grid83-113-Badge] |


### PR DESCRIPTION
**Issue #55**

## Motivation
<!-- This can usually be copied from the issue.
     Please do not just say, go see issue but instead
    copy the relevant details here. -->
We need to update all our workflows to use the stable versions of Drupal as Tripal will no longer be using the development versions of Drupal.

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

- [x] Update the docker build workflow
- [x] Update all the automated testing workflows
- [x] Update the README
- [x] Update the Dockerfiles to use 11.x-dev as the default

## Testing

### Automated Testing
<!-- Please describe each automated test this PR creates
     and provide a list of the assertions it makes using casual language.
     Do not just say things like "asserts the array is not empty"
     but rather say "Ensures that the return value of method X
     with these parameters is not an empty array". -->

Confirm that the automated testing works and that the versions you expect are present.