### PR TITLE
G0.62 Replaces the deprecated organism API method calls

### DIFF
--- a/trpcultivate_germcollection/src/Plugin/TripalImporter/GermplasmRelationshipImporter.php
+++ b/trpcultivate_germcollection/src/Plugin/TripalImporter/GermplasmRelationshipImporter.php
@@ -12,9 +12,11 @@ use Drupal\tripal\Services\TripalFileRetriever;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal\TripalBackendPublish\PluginManager\TripalBackendPublishManager;
 use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
+use Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\Controller\ChadoCVTermAutocompleteController;
 use Drupal\tripal_chado\Controller\ChadoGenericAutocompleteController;
+use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoOrganismBuddy;
 use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Drupal\trpcultivate\Plugin\Validators\EmptyCell;
 use Drupal\trpcultivate\Plugin\Validators\GermplasmNameExists;
@@ -26,6 +28,9 @@ use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ *
+ */
 #[TripalImporter(
   id: 'trpcultivate-germplasm-relationship-importer',
   label: new TranslatableMarkup('Tripal Cultivate: Relate Germplasm'),
@@ -101,6 +106,20 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
   protected ChadoConnection $chado_connection;
 
   /**
+   * The Chado Buddy service manager.
+   *
+   * @var Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager
+   */
+  protected ChadoBuddyPluginManager $buddy_manager;
+
+  /**
+   * An instance of the organism Chado Buddy.
+   *
+   * @var Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoOrganismBuddy
+   */
+  protected ChadoOrganismBuddy $organism_buddy;
+
+  /**
    * Headers required by this importer.
    *
    * @var array
@@ -162,6 +181,8 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
    *   The plugin implementation definition.
    * @param Drupal\tripal_chado\Database\ChadoConnection $chado_connection
    *   The connection to the Chado database.
+   * @param Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager $buddy_manager
+   *   The ChadoBuddy plugin manager.
    * @param Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager $service_validatorPluginManager
    *   The TripalCultivate validator plugin manager.
    * @param Drupal\trpcultivate\Service\TripalCultivateFileTemplateService $service_FileTemplate
@@ -184,6 +205,7 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
     string $plugin_id,
     mixed $plugin_definition,
     ChadoConnection $chado_connection,
+    ChadoBuddyPluginManager $buddy_manager,
     TripalCultivateValidatorManager $service_validatorPluginManager,
     TripalCultivateFileTemplateService $service_FileTemplate,
     EntityTypeManager $service_entityTypeManager,
@@ -211,6 +233,8 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
     $this->service_Messenger = $messenger;
     // Chado database.
     $this->chado_connection = $chado_connection;
+    $this->buddy_manager = $buddy_manager;
+    $this->organism_buddy = $this->buddy_manager->createInstance('chado_organism_buddy', []);
   }
 
   /**
@@ -222,6 +246,7 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
       $plugin_id,
       $plugin_definition,
       $container->get('tripal_chado.database'),
+      $container->get('tripal_chado.chado_buddy'),
       $container->get('plugin.manager.trpcultivate_validator'),
       $container->get('trpcultivate.template_generator'),
       $container->get('entity_type.manager'),
@@ -1134,9 +1159,9 @@ class GermplasmRelationshipImporter extends ChadoImporterBase implements Contain
         $scientific_name = $values['genus'] . ' ' . $values['species'];
 
         $organism_id = 0;
-        $organism_id_array = chado_get_organism_id_from_scientific_name($scientific_name);
-        if (array_key_exists(0, $organism_id_array)) {
-          $organism_id = $organism_id_array[0];
+        $organism_records = $this->organism_buddy->getOrganismFromScientificName($scientific_name);
+        if (array_key_exists(0, $organism_records)) {
+          $organism_id = $organism_records[0]->getValue('organism.organism_id');
         }
       }
       $this->organism_ids[$organism] = $organism_id;

--- a/trpcultivate_germcollection/src/Plugin/TripalImporter/GermplasmRelationshipImporter.php
+++ b/trpcultivate_germcollection/src/Plugin/TripalImporter/GermplasmRelationshipImporter.php
@@ -29,7 +29,10 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Tripal Cultivate Germplasm - Relationship Importer.
  *
+ * An importer to relate a group of germplasm to an existing germplasm using the
+ * stock_relationship table.
  */
 #[TripalImporter(
   id: 'trpcultivate-germplasm-relationship-importer',

--- a/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterRunTest.php
+++ b/trpcultivate_germcollection/tests/src/Kernel/TripalImporter/GermplamRelationshipImporter/GermplasmRelationshipImporterRunTest.php
@@ -7,6 +7,7 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoOrganismBuddy;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Controller\ChadoGenericAutocompleteController;
 use Drupal\tripal_chado\Controller\ChadoCVTermAutocompleteController;
@@ -47,6 +48,13 @@ class GermplasmRelationshipImporterRunTest extends ChadoTestKernelBase {
    * @var \Drupal\tripal_chado\Database\ChadoConnection
    */
   protected ChadoConnection $chado_connection;
+
+  /**
+   * An instance of the organism Chado Buddy.
+   *
+   * @var Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoOrganismBuddy
+   */
+  protected ChadoOrganismBuddy $organism_buddy;
 
   /**
    * Germplasm Relationship Importer plugin instance.
@@ -144,6 +152,10 @@ class GermplasmRelationshipImporterRunTest extends ChadoTestKernelBase {
       ])
       ->execute();
 
+    $buddy_manager = $container->get('tripal_chado.chado_buddy');
+
+    $this->organism_buddy = $buddy_manager->createInstance('chado_organism_buddy', []);
+
     $type_id = ChadoCVTermAutocompleteController::getCVtermId('cultivar (EFO:0005136)');
 
     $stock_id = $this->chado_connection->insert('1:stock')
@@ -161,6 +173,7 @@ class GermplasmRelationshipImporterRunTest extends ChadoTestKernelBase {
       'trpcultivate-germplasm-relationship-importer',
       $this->definitions,
       $this->chado_connection,
+      $buddy_manager,
       $container->get('plugin.manager.trpcultivate_validator'),
       $container->get('trpcultivate.template_generator'),
       $container->get('entity_type.manager'),
@@ -379,7 +392,7 @@ class GermplasmRelationshipImporterRunTest extends ChadoTestKernelBase {
         );
         // Check if the organism is inserted correctly.
         $this->assertEquals(
-          $stock_organism = chado_get_organism_id_from_scientific_name($expected_stock['organism'])[0],
+          $stock_organism = $this->organism_buddy->getOrganismFromScientificName($expected_stock['organism'])[0]->getValue('organism.organism_id'),
           $stock_query[$index]->organism_id,
           'We expected the inserted stock to have an organism id of ' . $stock_organism . ', but it was ' . $stock_query[$index]->organism_id . '.',
         );

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmAccessionImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmAccessionImporter.php
@@ -12,7 +12,8 @@ use Drupal\tripal\Services\TripalFileRetriever;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal\TripalBackendPublish\PluginManager\TripalBackendPublishManager;
 use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
-
+use Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager;
+use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoOrganismBuddy;
 
 #[TripalImporter(
    id: 'trpcultivate-germplasm-accession',
@@ -43,6 +44,20 @@ class GermplasmAccessionImporter extends ChadoImporterBase {
    * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
   protected $config_factory;
+
+  /**
+   * The Chado Buddy service manager.
+   *
+   * @var Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager
+   */
+  protected ChadoBuddyPluginManager $buddy_manager;
+
+  /**
+   * An instance of the organism Chado Buddy.
+   *
+   * @var Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoOrganismBuddy
+   */
+  protected ChadoOrganismBuddy $organism_buddy;
 
   /**
    * An associative array of cvterms as the key and the cvterm_id as the value.
@@ -83,6 +98,7 @@ class GermplasmAccessionImporter extends ChadoImporterBase {
       $plugin_id,
       $plugin_definition,
       $container->get('tripal_chado.database'),
+      $container->get('tripal_chado.chado_buddy'),
       $container->get('config.factory'),
       $container->get('messenger'),
       $container->get('tripal.logger'),
@@ -106,6 +122,8 @@ class GermplasmAccessionImporter extends ChadoImporterBase {
    * @param string $plugin_id
    * @param mixed $plugin_definition
    * @param Drupal\tripal_chado\Database\ChadoConnection $connection
+   * @param Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager $buddy_manager
+   *   The ChadoBuddy plugin manager.
    * @param
    */
   public function __construct(
@@ -113,6 +131,7 @@ class GermplasmAccessionImporter extends ChadoImporterBase {
     $plugin_id,
     $plugin_definition,
     ChadoConnection $connection,
+    ChadoBuddyPluginManager $buddy_manager,
     ConfigFactoryInterface $config_factory,
     Messenger $messenger,
     TripalLogger $logger,
@@ -131,6 +150,8 @@ class GermplasmAccessionImporter extends ChadoImporterBase {
     );
 
     $this->config_factory = $config_factory;
+    $this->buddy_manager = $buddy_manager;
+    $this->organism_buddy = $this->buddy_manager->createInstance('chado_organism_buddy', []);
   }
 
   /**
@@ -427,7 +448,7 @@ class GermplasmAccessionImporter extends ChadoImporterBase {
     if ($germplasm_subtaxa) {
       $organism_name = $organism_name . ' ' . $germplasm_subtaxa;
     }
-    $organism_array = chado_get_organism_id_from_scientific_name($organism_name);
+    $organism_array = $this->organism_buddy->getOrganismFromScientificName($organism_name);
 
     if (!$organism_array) {
       $this->logger->error("Could not find an organism \"@organism_name\" in the database.", ['@organism_name' => $organism_name]);
@@ -442,7 +463,7 @@ class GermplasmAccessionImporter extends ChadoImporterBase {
       return false;
     }
 
-    return $organism_array[0];
+    return $organism_array[0]->getValue('organism.organism_id');
   }
 
   /**

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterRunTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterRunTest.php
@@ -102,6 +102,7 @@ class GermplasmAccessionImporterRunTest extends ChadoTestKernelBase {
       'trpcultivate-germplasm-accession',
       $this->definitions,
       $this->connection,
+      $container->get('tripal_chado.chado_buddy'),
       $this->config_factory,
       $container->get('messenger'),
       $container->get('tripal.logger'),

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporter/GermplasmAccessionImporterTest.php
@@ -90,6 +90,7 @@ class GermplasmAccessionImporterTest extends ChadoTestKernelBase {
       'trpcultivate-germplasm-accession',
       $this->definitions,
       $this->connection,
+      $container->get('tripal_chado.chado_buddy'),
       $this->config_factory,
       $container->get('messenger'),
       $container->get('tripal.logger'),


### PR DESCRIPTION
**Issue #62**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->
After deprecating the organism API methods on tripal, the automated tests are failing in this module due to those organism api method calls. We need to replace those with the organism buddy methods as indicated in the deprecation notices.

## What does this PR do?
<!-- *Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.* -->
Replaces the Organism API method calls with the ChadoOrganismBuddy methods.
1. Replaces `chado_get_organism_id_from_scientific_name()` method call with ChadoOrganismBuddy getOrganismFromScientificName() method in `GermplasmRelationshipImporter`
2. Replaces `chado_get_organism_id_from_scientific_name()` method call with ChadoOrganismBuddy getOrganismFromScientificName() method in `GermplasmAccessionImporter`

## Testing

### Automated Testing
No new tests have been added. However, all the existing automated tests should be passing.