### PR TITLE
G2.58 Updates to the Germplasm Cross Importer

### DIFF
--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -462,9 +462,12 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       '#required' => TRUE,
     ];
 
-    $programs_query = $this->chado_connection->select('1:dbprop', 'dbp')
-      ->fields('dbp', ['db_id'])
-      ->orderBy('value');
+    $programs_query = $this->chado_connection->select('1:db', 'db')
+      ->distinct()
+      ->fields('db', ['db_id', 'name']);
+    $programs_query->join('1:dbprop', 'dbp', 'db.db_id = dbp.db_id');
+    $programs_query->condition('dbp.value', 'Program ID', '=');
+    $programs_query->orderBy('name');
     $all_programs = $programs_query->execute()->fetchAllKeyed(0, 1);
 
     // Field Program ID.

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -125,7 +125,7 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
   protected ChadoBuddyPluginManager $buddy_manager;
 
   /**
-   * The Chado Buddy cvterm.
+   * An instance of the cvterm Chado Buddy.
    *
    * @var \Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoCvtermBuddy
    */
@@ -407,6 +407,20 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
     $instance->setIndices($indices);
     $instance->setGenus($form_values['genus']);
     $validators['data-row']['germplasm_name_exists'] = $instance;
+
+    /*
+    // - Cross Type is a valid cross type in the database.
+    $instance = $this->service_validatorPluginManager->createInstance('value_in_list');
+    $instance->setIndices([$header_index['Cross Type']]);
+    $valid_cross_types = $this->cvterm_buddy->getCvterm([
+      'cvterm.name' => 'additionalType',
+      'cv.name' => 'schema',
+      'cv.accession' => 'additionalType',
+    ]);
+    $instance->setValidValues($valid_cross_types);
+    $validators['data-row']['valid_cross_type'] = $instance;
+    */
+
     return $validators;
   }
 

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -89,11 +89,6 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       'type' => 'required',
     ],
     [
-      'name' => 'Unique Name',
-      'description' => 'A unique identifier for this cross. This can be the same as Cross Number, if desired.',
-      'type' => 'required',
-    ],
-    [
       'name' => 'Species',
       'description' => 'The species of the germplasm being imported.',
       'type' => 'required',
@@ -112,21 +107,6 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       'name' => 'Cross Type',
       'description' => 'The type of cross (e.g. single, double, triple).',
       'type' => 'required',
-    ],
-    [
-      'name' => 'Seed Type',
-      'description' => 'Either the market class or the seed coat colour of the seed resulting from this cross.',
-      'type' => 'optional',
-    ],
-    [
-      'name' => 'Cotyledon Colour',
-      'description' => 'The cotyledon colour of the seed resulting from this cross.',
-      'type' => 'optional',
-    ],
-    [
-      'name' => 'Comment',
-      'description' => 'A free-text comment about this cross.',
-      'type' => 'optional',
     ],
   ];
 
@@ -392,7 +372,6 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       $header_index['Year'],
       $header_index['Season'],
       $header_index['Cross Number'],
-      $header_index['Unique Name'],
       $header_index['Species'],
       $header_index['Maternal Parent'],
       $header_index['Paternal Parent'],

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -424,13 +424,19 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       'cv.name' => 'schema',
       'dbxref.accession' => 'additionalType',
     ]);
+    if (empty($additionalType_cvterm)) {
+      $this->service_Messenger->addError($this->t('The cvterm "additionalType" could not be found in the database. Please check with your administrator to ensure cross types of type "additionalType" are present in the database before importing germplasm cross data.'));
+    }
+
     $additionalType_cvterm_id = $additionalType_cvterm[0]->getValue('cvterm.cvterm_id');
-    // Grab all the valid cross types from the stockprop table.
+    // Grab all the valid cross types from the stockprop table. Germplasm
+    // cross types such as "single" and "double" are stored in the stockprop
+    // table with the type "additionalType".
     $valid_cross_types_query = $this->chado_connection->select('1:stockprop', 'sp')
       ->fields('sp', ['value'])
       ->condition('sp.type_id', $additionalType_cvterm_id, '=')
       ->distinct();
-    $valid_cross_types = $valid_cross_types_query->execute()->fetchAllKeyed(0, 0);
+    $valid_cross_types = $valid_cross_types_query->execute()->fetchCol();
     if (!$valid_cross_types) {
       $this->service_Messenger->addError($this->t('No cross types were found in the database. Please contact your administrator to add cross types to the database before importing germplasm cross data.'));
     }
@@ -502,12 +508,12 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
     $programs_query->orderBy('db.name')
       ->distinct();
 
-    $all_programs = $programs_query->execute()->fetchAllKeyed(0, 0);
+    $all_programs = $programs_query->execute()->fetchCol();
 
     // If there is only one program, it should be the default.
     $default_program = '';
-    if ($all_programs && count($all_programs) == 1) {
-      $default_program = array_keys($all_programs)[0];
+    if (count($all_programs) == 1) {
+      $default_program = $all_programs[0];
     }
     // If there are no programs, let the user know that one or more needs to be
     // added to the database before importing germplasm cross data.
@@ -522,7 +528,7 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       '#description' => $this->t('The program ID of the germplasm being imported.'),
       '#empty_value' => '',
       '#empty_option' => '- Select -',
-      '#options' => $all_programs,
+      '#options' => array_combine($all_programs, $all_programs),
       '#default_value' => $default_program,
       '#weight' => -98,
       '#required' => TRUE,

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -463,12 +463,13 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
     ];
 
     $programs_query = $this->chado_connection->select('1:db', 'db')
-      ->distinct()
-      ->fields('db', ['db_id', 'name']);
+      ->fields('db', ['name']);
     $programs_query->join('1:dbprop', 'dbp', 'db.db_id = dbp.db_id');
     $programs_query->condition('dbp.value', 'Program ID', '=');
-    $programs_query->orderBy('name');
-    $all_programs = $programs_query->execute()->fetchAllKeyed(0, 1);
+    $programs_query->orderBy('db.name')
+      ->distinct();
+
+    $all_programs = $programs_query->execute()->fetchAllKeyed(0, 0);
 
     // Field Program ID.
     $form['program_id'] = [

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -207,6 +207,13 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
   ];
 
   /**
+   * Stores the valid values for the 'Cross Types' column.
+   *
+   * @var array
+   */
+  protected array $valid_cross_types = [];
+
+  /**
    * Constructs the cross importer.
    *
    * @param array $configuration
@@ -408,18 +415,30 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
     $instance->setGenus($form_values['genus']);
     $validators['data-row']['germplasm_name_exists'] = $instance;
 
-    /*
     // - Cross Type is a valid cross type in the database.
     $instance = $this->service_validatorPluginManager->createInstance('value_in_list');
     $instance->setIndices([$header_index['Cross Type']]);
-    $valid_cross_types = $this->cvterm_buddy->getCvterm([
+    // Grab the cvterm ID for 'additionalType'.
+    $additionalType_cvterm = $this->cvterm_buddy->getCvterm([
       'cvterm.name' => 'additionalType',
       'cv.name' => 'schema',
-      'cv.accession' => 'additionalType',
+      'dbxref.accession' => 'additionalType',
     ]);
-    $instance->setValidValues($valid_cross_types);
-    $validators['data-row']['valid_cross_type'] = $instance;
-    */
+    $additionalType_cvterm_id = $additionalType_cvterm[0]->getValue('cvterm.cvterm_id');
+    // Grab all the valid cross types from the stockprop table.
+    $valid_cross_types_query = $this->chado_connection->select('1:stockprop', 'sp')
+      ->fields('sp', ['value'])
+      ->condition('sp.type_id', $additionalType_cvterm_id, '=')
+      ->distinct();
+    $valid_cross_types = $valid_cross_types_query->execute()->fetchAllKeyed(0, 0);
+    if (!$valid_cross_types) {
+      $this->service_Messenger->addError($this->t('No cross types were found in the database. Please contact your administrator to add cross types to the database before importing germplasm cross data.'));
+    }
+    else {
+      $this->valid_cross_types = $valid_cross_types;
+      $instance->setValidValues($this->valid_cross_types);
+      $validators['data-row']['valid_cross_type'] = $instance;
+    }
 
     return $validators;
   }
@@ -815,6 +834,11 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
         'status' => 'todo',
         'details' => '',
       ],
+      'valid_cross_type' => [
+        'title' => 'Values in column "Cross Type" are valid',
+        'status' => 'todo',
+        'details' => '',
+      ],
     ];
 
     $header_names = array_column($this->headers, 'name');
@@ -963,6 +987,26 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
         $messages[$validator_name]['status'] = 'pass';
       }
       // Otherwise, leave status as 'todo' since 1+ raw rows failed.
+    }
+
+    // Valid Cross Type.
+    $validator_name = 'valid_cross_type';
+    if (array_key_exists($validator_name, $failures)) {
+      if (!empty($failures[$validator_name])) {
+        $messages[$validator_name]['status'] = 'fail';
+        $metadata = [
+          'expected_values' => $this->valid_cross_types,
+          'column_headers' => [
+            // Cross Type.
+            6 => $header_names[6],
+          ],
+        ];
+        $messages[$validator_name]['details'] = ValueInList::processListWithDescribedTable($failures[$validator_name], $metadata);
+      }
+      // Only pass if raw row validation didn't fail.
+      elseif (!$raw_row_failed) {
+        $messages[$validator_name]['status'] = 'pass';
+      }
     }
 
     return $messages;

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -462,6 +462,25 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       '#required' => TRUE,
     ];
 
+    /*$programs_query = $this->chado_connection->select('1:dbprop', 'dbp')
+      ->fields('dbp', ['db_id'])
+      ->orderBy('name');
+    $all_programs = $programs_query->execute()->fetchAllKeyed(0, 1);
+
+    // Field Program ID.
+    $form['program_id'] = [
+      '#type' => 'select',
+      '#title' => 'Program ID',
+      '#description' => $this->t('The program ID of the germplasm being imported.'),
+      '#empty_value' => '',
+      '#empty_option' => '- Select -',
+      '#options' => $all_programs,
+      '#default_value' => '',
+      '#weight' => -98,
+      '#required' => TRUE,
+    ];
+    */
+
     // This importer does not support using file sources from existing field.
     // #access: (bool) Whether the element is accessible or not; when FALSE,
     // the element is not rendered and the user submitted value is not taken

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -462,9 +462,9 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       '#required' => TRUE,
     ];
 
-    /*$programs_query = $this->chado_connection->select('1:dbprop', 'dbp')
+    $programs_query = $this->chado_connection->select('1:dbprop', 'dbp')
       ->fields('dbp', ['db_id'])
-      ->orderBy('name');
+      ->orderBy('value');
     $all_programs = $programs_query->execute()->fetchAllKeyed(0, 1);
 
     // Field Program ID.
@@ -479,7 +479,6 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       '#weight' => -98,
       '#required' => TRUE,
     ];
-    */
 
     // This importer does not support using file sources from existing field.
     // #access: (bool) Whether the element is accessible or not; when FALSE,

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -471,6 +471,17 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
 
     $all_programs = $programs_query->execute()->fetchAllKeyed(0, 0);
 
+    // If there is only one program, it should be the default.
+    $default_program = '';
+    if ($all_programs && count($all_programs) == 1) {
+      $default_program = array_keys($all_programs)[0];
+    }
+    // If there are no programs, let the user know that one or more needs to be
+    // added to the database before importing germplasm cross data.
+    if (!$all_programs) {
+      $this->service_Messenger->addError($this->t('No Program IDs were found in the database. Please contact your administrator to add your Program ID to the database before importing germplasm cross data.'));
+    }
+
     // Field Program ID.
     $form['program_id'] = [
       '#type' => 'select',
@@ -479,7 +490,7 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
       '#empty_value' => '',
       '#empty_option' => '- Select -',
       '#options' => $all_programs,
-      '#default_value' => '',
+      '#default_value' => $default_program,
       '#weight' => -98,
       '#required' => TRUE,
     ];

--- a/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
+++ b/trpcultivate_germplasm/src/Plugin/TripalImporter/GermplasmCrossImporter.php
@@ -867,7 +867,7 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
           'column_headers' => [
             // "Scientific Name" here refers to the combination of the
             // form field 'Genus' and the value in column 'Species'.
-            4 => 'Scientific Name',
+            3 => 'Scientific Name',
           ],
         ];
         $messages[$validator_name]['details'] = ValidOrganism::processListWithDescribedTable($failures[$validator_name], $metadata, $tokens);
@@ -904,9 +904,9 @@ class GermplasmCrossImporter extends ChadoImporterBase implements ContainerFacto
         $metadata = [
           'column_headers' => [
             // Maternal Parent.
-            5 => $header_names[5],
+            4 => $header_names[4],
             // Paternal Parent.
-            6 => $header_names[6],
+            5 => $header_names[5],
           ],
         ];
         $messages[$validator_name]['details'] = GermplasmNameExists::processListWithDescribedTable($failures[$validator_name], $metadata);

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_emptycell_crossnumber.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_emptycell_crossnumber.tsv
@@ -1,3 +1,3 @@
-Year	Season	Cross Number	Unique Name	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
-2021	Winter			databasica	121S	122S	single
-2022	Spring	125S	125S	databasica	122S	121S	single
+Year	Season	Cross Number	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
+2021	Winter		databasica	121S	122S	single
+2022	Spring	125S	databasica	122S	121S	single

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_improperly_delimited_data_row.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_improperly_delimited_data_row.tsv
@@ -1,2 +1,2 @@
-"Year"	"Season"	"Cross Number"	"Unique Name"	"Species"	"Maternal Parent"	"Paternal Parent"	"Cross Type"	"Seed Type"	"Cotyledon Colour"	"Comment"
-"2021 Winter"	"123S"	"123S"	"databasica"	"121S 122S"	"single"
+"Year"	"Season"	"Cross Number"	"Species"	"Maternal Parent"	"Paternal Parent"	"Cross Type"	"Seed Type"	"Cotyledon Colour"	"Comment"
+"2021 Winter"	"123S"	"databasica"	"121S 122S"	"single"

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_invalid_cross_type.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_invalid_cross_type.tsv
@@ -1,0 +1,3 @@
+Year	Season	Cross Number	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
+2021	Winter	123S	databasica	121S	122S	single
+2022	Spring	125S	databasica	122S	121S	invalid

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_invalid_season.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_invalid_season.tsv
@@ -1,3 +1,3 @@
-Year	Season	Cross Number	Unique Name	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
-2021	Winter	123S	123S	databasica	121S	122S	single
-2022	Autumn	125S	125S	databasica	122S	121S	single
+Year	Season	Cross Number	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
+2021	Winter	123S	databasica	121S	122S	single
+2022	Autumn	125S	databasica	122S	121S	single

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_no_data.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_no_data.tsv
@@ -1,1 +1,1 @@
-Year	Season	Cross Number	Unique Name	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
+Year	Season	Cross Number	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_nonexistent_maternal_parent.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_nonexistent_maternal_parent.tsv
@@ -1,3 +1,3 @@
-Year	Season	Cross Number	Unique Name	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
-2021	Winter	123S	123S	databasica	121S	122S	single
-2022	Spring	125S	125S	databasica	DNE-Mom	122S	single
+Year	Season	Cross Number	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
+2021	Winter	123S	databasica	121S	122S	single
+2022	Spring	125S	databasica	DNE-Mom	122S	single

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_nonexistent_organism.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_nonexistent_organism.tsv
@@ -1,3 +1,3 @@
-Year	Season	Cross Number	Unique Name	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
+Year	Season	Cross Number	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
 
-2021	Winter	123S	123S	ervoides	121S	122S	single
+2021	Winter	123S	ervoides	121S	122S	single

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_preexisting_crossnum.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_preexisting_crossnum.tsv
@@ -1,3 +1,3 @@
-Year	Season	Cross Number	Unique Name	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
-2021	Winter	123S	123S	databasica	121S	122S	single
-2022	Spring	122S	122S	databasica	121S	124S	single
+Year	Season	Cross Number	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
+2021	Winter	123S	databasica	121S	122S	single
+2022	Spring	122S	databasica	121S	124S	single

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/crosses_simple.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/crosses_simple.tsv
@@ -1,4 +1,4 @@
-Year	Season	Cross Number	Unique Name	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
+Year	Season	Cross Number	Species	Maternal Parent	Paternal Parent	Cross Type	Seed Type	Cotyledon Colour	Comment
 
-2021	Winter	123S	123S	databasica	121S	122S	single
-2022	Spring	125S	125S	databasica	121S	124S	single
+2021	Winter	123S	databasica	121S	122S	single
+2022	Spring	125S	databasica	121S	124S	single

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/improperly_delimited_header_with_data.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/improperly_delimited_header_with_data.tsv
@@ -1,3 +1,3 @@
-"Year"	"Season"	"Cross Number"	"Unique Name"	"Species"	"Maternal Parent Paternal Parent"	"Cross Type"	"Seed Type"	"Cotyledon Colour"	"Comment"
-"2021"	"Winter"	"123S"	"123S"	"databasica"	"121S"	"122S"	"single"
-2022	Spring	125S	125S	databasica	121S	124S	single
+"Year"	"Season"	"Cross Number"	"Species"	"Maternal Parent Paternal Parent"	"Cross Type"	"Seed Type"	"Cotyledon Colour"	"Comment"
+"2021"	"Winter"	"123S"	"databasica"	"121S"	"122S"	"single"
+2022	Spring	125S	databasica	121S	124S	single

--- a/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/incorrect_header_with_data.tsv
+++ b/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/incorrect_header_with_data.tsv
@@ -1,3 +1,3 @@
-Year	Season	Cross Number	Unique Name	Species	Maternal Parent	Paternal Parent	WRONG HEADER	Seed Type	Cotyledon Colour	Comment
-2021	Winter	123S	123S	databasica	121S	122S	single
-2022	Spring	125S	125S	databasica	121S	124S	single
+Year	Season	Cross Number	Species	Maternal Parent	Paternal Parent	WRONG HEADER	Seed Type	Cotyledon Colour	Comment
+2021	Winter	123S	databasica	121S	122S	single
+2022	Spring	125S	databasica	121S	124S	single

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -289,23 +289,17 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     }
 
     // Use a CVterm ChadoBuddy to get the cvterm_id for inserting Program IDs.
-    /*
     $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
     $cvterm_buddy = $buddy_service->createInstance('chado_cvterm_buddy', []);
-    $cv_record = $cvterm_buddy->insertCv([
-    'cv.name' => 'refs',
+    $cvterm_record = $cvterm_buddy->getCvterm([
+      'cv.name' => 'rdfs',
+      'cvterm.name' => 'type',
     ]);
-    $cvterm_record = $cvterm_buddy->insertCvterm([
-    'cvterm.name' => 'type',
-    'buddy_record' => $cv_record,
-    ]);
-    $cvterm_id = $cvterm_record->getValue('cvterm_id');
+    $cvterm_id = $cvterm_record[0]->getValue('cvterm.cvterm_id');
     $this->assertIsNumeric($cvterm_id,
     'We were not able to get the cvterm_id we need for creating Program ID dbprop records.');
-     */
 
     // Insert any Program IDs if available.
-    $cvterm_id = '1';
     if ($programs['programs']) {
       foreach ($programs['programs'] as $program) {
         // Create the db record for this Program ID.

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -8,6 +8,8 @@ use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoCvtermBuddy;
+use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoPropertyBuddy;
 use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -55,6 +57,20 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
    * @var \Drupal\tripal_chado\Database\ChadoConnection
    */
   protected ChadoConnection $chado_connection;
+
+  /**
+   * An instance of the ChadoCvtermBuddy.
+   *
+   * @var \Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoCvtermBuddy
+   */
+  protected ChadoCvtermBuddy $cvterm_buddy;
+
+  /**
+   * An instance of the ChadoPropertyBuddy.
+   *
+   * @var \Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoPropertyBuddy
+   */
+  protected ChadoPropertyBuddy $property_buddy;
 
   /**
    * A default listing of annotations associated with our importer.
@@ -133,61 +149,96 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Data Provider: provides genus and the expected default genus.
+   * Data Provider: provides values to test the Cross Importer form's dropdowns.
    *
    * @return array
    *   Each scenario is an array with the following:
-   *   - A nested array of organisms to insert into the database, contains the
-   *   genus to create the form field dropdown. Each organism array
-   *   has the following keys:
-   *     - 'genus': A string of the genus to insert.
-   *     - 'species': A string of the species to insert.
-   *   - The genus that is expected to be shown to the user by default.
-   *   - The string message to be passed into assertEquals when evaluating the
-   *     default genus.
+   *   - A nested array with information to test the "genus" form field, with
+   *     the following keys:
+   *     - 'organisms': A nested array of organisms to insert into the database,
+   *       contains the genus to create the form field dropdown. Each organism
+   *       array has the following keys:
+   *       - 'genus': A string of the genus to insert.
+   *       - 'species': A string of the species to insert.
+   *     - 'default': The genus expected to be shown to the user by default.
+   *     - 'message': The string message to be passed into assertEquals when
+   *       evaluating the default genus.
+   *   - A nested array with information to test the "program" form field, with
+   *     the following keys:
+   *     - 'programs': A nested array of Program IDs to insert into the
+   *       database, contains the program name to create the form field
+   *       dropdown. Each program array has the following keys:
+   *       - 'name': A string of the program "code" to insert.
+   *     - 'default': The program name expected to be shown to the user by
+   *       default.
+   *     - 'message': The string message to be passed into assertEquals when
+   *       evaluating the default program name.
    */
-  public static function provideGenusForForm() {
+  public static function provideValuesForForm() {
     $scenarios = [];
 
-    // #0: No organisms exist in the database.
+    // #0: No organisms & program IDs exist in the database.
     $scenarios[] = [
-      [],
-      '',
-      'We expect the genus element in the form to default to empty option since no organisms are available.',
+      [
+        'organisms' => [],
+        'default' => '',
+        'message' => 'We expect the genus element in the form to default to empty option since no organisms are available.',
+      ],
+      [
+        'programs' => [],
+        'default' => '',
+        'message' => 'We expect the program element in the form to default to empty option since no programs are available.',
+      ],
     ];
 
     // #1: 1 valid organism
     $scenarios[] = [
       [
-        [
-          'genus' => 'Tripalus',
-          'species' => 'databasica',
+        'organisms' => [
+          [
+            'genus' => 'Tripalus',
+            'species' => 'databasica',
+          ],
         ],
+        'default' => 'Tripalus',
+        'message' => 'We expect the genus element in the form to default to Tripalus as it is the genus of the organism we created.',
       ],
-      'Tripalus',
-      'We expect the genus element in the form to default to Tripalus as it is the genus of the organism we created.',
+      [
+        'programs' => [],
+        'default' => '',
+        'message' => 'We expect the program element in the form to default to empty option
+        since no programs are available.',
+      ],
     ];
 
     // #2: 3 valid organisms
     $scenarios[] = [
       [
-        [
-          'genus' => 'Tripalus',
-          'species' => 'databasica',
+        'organisms' => [
+          [
+            'genus' => 'Tripalus',
+            'species' => 'databasica',
+          ],
+          [
+            'genus' => 'Tripalus',
+            'species' => 'chadoii',
+          ],
+          [
+            'genus' => 'Lorem',
+            'species' => 'ipsum',
+          ],
         ],
-        [
-          'genus' => 'Tripalus',
-          'species' => 'chadoii',
-        ],
-        [
-          'genus' => 'Lorem',
-          'species' => 'ipsum',
-        ],
+        // Since there is more than one organism, the default option is expected
+        // to be the -Select- text, therefore empty value.
+        'default' => '',
+        'message' => 'We expect the genus element in the form to default to empty option since more than one organism is available.',
       ],
-      // Since there is more than one organism, the default option is expected
-      // to be the -Select- text, therefore empty value.
-      '',
-      'We expect the genus element in the form to default to empty option since more than one organism is available.',
+      [
+        'programs' => [],
+        'default' => '',
+        'message' => 'We expect the program element in the form to default to empty option
+        since no programs are available.',
+      ],
     ];
 
     return $scenarios;
@@ -196,29 +247,39 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
   /**
    * Tests building the importer form with a variable number of organisms.
    *
-   * @param array $organisms
-   *   A nested array of organisms to insert into the database, contains the
-   *   genus to create the form field dropdown. Each organism array
+   * @param array $genus
+   *   A nested array with information to test the "genus" form field, with the
+   *   following keys:
+   *   - 'organisms': A nested array of organisms to insert into the database,
+   *   contains the genus to create the form field dropdown. Each organism array
    *   has the following keys:
-   *   - 'genus': A string of the genus to insert.
-   *   - 'species': A string of the species to insert.
-   * @param string $default_genus
-   *   The genus that is expected to be shown to the user by default.
-   * @param string $assert_organism_field_message
-   *   The string message to be passed into assertEquals when evaluating the
-   *   default genus.
+   *     - 'genus': A string of the genus to insert.
+   *     - 'species': A string of the species to insert.
+   *   - 'default': The genus expected to be shown to the user by default.
+   *   - 'message': The string message to be passed into assertEquals when
+   *     evaluating the default genus.
+   * @param array $programs
+   *   A nested array with information to test the "Program IDs" form field,
+   *   with the following keys:
+   *   - 'programs': A nested array of Program IDs to insert into the database,
+   *     contains the program name to create the form field dropdown. Each
+   *     program array has the following keys:
+   *     - 'name': A string of the program "code" to insert.
+   *   - The program name expected to be shown to the user by default.
+   *   - The string message to be passed into assertEquals when evaluating
+   *     the default program ID name.
    *
-   * @dataProvider provideGenusForForm
+   * @dataProvider provideValuesForForm
    */
-  #[DataProvider('provideGenusForForm')]
-  public function testCrossImporterForm(array $organisms, string $default_genus, string $assert_organism_field_message) {
+  #[DataProvider('provideValuesForForm')]
+  public function testCrossImporterForm(array $genus, array $programs) {
 
     $plugin_id = 'trpcultivate-germplasm-cross-importer';
     $importer_label = 'Tripal Cultivate: Germplasm Cross Importer';
 
     // Insert any organisms if available.
-    if ($organisms) {
-      foreach ($organisms as $organism) {
+    if ($genus['organisms']) {
+      foreach ($genus['organisms'] as $organism) {
         $organism_id = $this->chado_connection->insert('1:organism')
           ->fields($organism)
           ->execute();
@@ -226,6 +287,41 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
         'We were not able to create the organism "' . $organism['genus'] . $organism['species'] . '" for testing.');
       }
     }
+
+    /*
+    // Use a CVterm ChadoBuddy to get the cvterm_id for inserting Program IDs.
+    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+    $cvterm_buddy = $buddy_service->createInstance('chado_cvterm_buddy', []);
+    $cvterm_record = $cvterm_buddy->insertCvterm([
+      'cv.name' => 'refs',
+      'cvterm.name' => 'type',
+    ]);
+    $cvterm_id = $cvterm_record->getValue('cvterm_id');
+    $this->assertIsNumeric($cvterm_id,
+      'We were not able to get the cvterm_id we need for creating Program ID dbprop records.');
+
+    // Insert any Program IDs if available.
+    if ($programs['programs']) {
+      foreach ($programs['programs'] as $program) {
+        // Create the db record for this Program ID.
+        $program_id = $this->chado_connection->insert('1:db')
+          ->fields($program)
+          ->execute();
+        // Create the dbprop record and link it to the db record.
+        $dbprop_id = $this->chado_connection->insert('1:dbprop')
+          ->fields([
+            'db_id' => $program_id,
+            'type_id' => $cvterm_id,
+            'value' => 'Program ID',
+          ])
+          ->execute();
+        $this->assertIsNumeric($program_id,
+          'We were not able to create the program "' . $program['name'] . '" in the db table for testing.');
+        $this->assertIsNumeric($dbprop_id,
+          'We were not able to create the dbprop record for program "' . $program['name'] . '" for testing.');
+      }
+    }
+    */
 
     // Build the form using the Drupal form builder.
     $form = \Drupal::formBuilder()->getForm(
@@ -285,13 +381,13 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     $this->assertEquals('select', $form['genus']['#type'],
       "We expect the genus element in the form to be a select list.");
     // Check that the select list contains all of our genus.
-    foreach ($organisms as $organism) {
+    foreach ($genus['organisms'] as $organism) {
       $this->assertArrayHasKey($organism['genus'], $form['genus']['#options'],
         "We expect the genus select list to contain the genus" . $organism['genus'] . ".");
     }
     // Check the select list's default value.
-    $this->assertEquals($default_genus, $form['genus']['#default_value'],
-      $assert_organism_field_message);
+    $this->assertEquals($genus['default'], $form['genus']['#default_value'],
+      $genus['message']);
   }
 
   /**

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -421,6 +421,36 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     $this->assertIsNumeric($organism_id,
       "We were not able to create an organism for testing.");
 
+    // Use a CVterm ChadoBuddy to get the cvterm_id for inserting Program IDs.
+    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+    $cvterm_buddy = $buddy_service->createInstance('chado_cvterm_buddy', []);
+    $cvterm_record = $cvterm_buddy->getCvterm([
+      'cv.name' => 'rdfs',
+      'cvterm.name' => 'type',
+    ]);
+    $cvterm_id = $cvterm_record[0]->getValue('cvterm.cvterm_id');
+    $this->assertIsNumeric($cvterm_id,
+    'We were not able to get the cvterm_id we need for creating Program ID dbprop records.');
+
+    $program_name = 'Test Program';
+    $program_id = $this->chado_connection->insert('1:db')
+      ->fields([
+        'name' => $program_name,
+      ])
+      ->execute();
+    // Create the dbprop record and link it to the db record.
+    $dbprop_id = $this->chado_connection->insert('1:dbprop')
+      ->fields([
+        'db_id' => $program_id,
+        'type_id' => $cvterm_id,
+        'value' => 'Program ID',
+      ])
+      ->execute();
+    $this->assertIsNumeric($program_id,
+          'We were not able to create the program "' . $program_name . '" in the db table for testing.');
+    $this->assertIsNumeric($dbprop_id,
+          'We were not able to create the dbprop record for program "' . $program_name . '" for testing.');
+
     // Create a file to upload.
     $file = $this->createTestFile([
       'filename' => 'crosses_simple.tsv',
@@ -434,6 +464,7 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     $form_state = new FormState();
     $form_state->addBuildInfo('args', [$plugin_id]);
     $form_state->setValue('genus', $genus);
+    $form_state->setValue('program_id', $program_id);
     $form_state->setValue('file_upload', $file->id());
 
     // Now try validation!

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -9,6 +9,7 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoCvtermBuddy;
+use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoDbxrefBuddy;
 use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoPropertyBuddy;
 use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
@@ -64,6 +65,13 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
    * @var \Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoCvtermBuddy
    */
   protected ChadoCvtermBuddy $cvterm_buddy;
+
+  /**
+   * An instance of the ChadoDbxrefBuddy.
+   *
+   * @var \Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoDbxrefBuddy
+   */
+  protected ChadoDbxrefBuddy $dbxref_buddy;
 
   /**
    * An instance of the ChadoPropertyBuddy.
@@ -146,6 +154,12 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     $this->module_path = $this->container->get('module_handler')
       ->getModule('trpcultivate_germplasm')
       ->getPath();
+
+    // Setup our ChadoBuddies.
+    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+    $this->cvterm_buddy = $buddy_service->createInstance('chado_cvterm_buddy', []);
+    $this->dbxref_buddy = $buddy_service->createInstance('chado_dbxref_buddy', []);
+    $this->property_buddy = $buddy_service->createInstance('chado_property_buddy', []);
   }
 
   /**
@@ -303,9 +317,7 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     }
 
     // Use a CVterm ChadoBuddy to get the cvterm_id for inserting Program IDs.
-    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
-    $cvterm_buddy = $buddy_service->createInstance('chado_cvterm_buddy', []);
-    $cvterm_record = $cvterm_buddy->getCvterm([
+    $cvterm_record = $this->cvterm_buddy->getCvterm([
       'cv.name' => 'rdfs',
       'cvterm.name' => 'type',
     ]);
@@ -317,20 +329,18 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     if ($programs['programs']) {
       foreach ($programs['programs'] as $program) {
         // Create the db record for this Program ID.
-        $program_id = $this->chado_connection->insert('1:db')
-          ->fields($program)
-          ->execute();
-        // Create the dbprop record and link it to the db record.
-        $dbprop_id = $this->chado_connection->insert('1:dbprop')
-          ->fields([
-            'db_id' => $program_id,
-            'type_id' => $cvterm_id,
-            'value' => 'Program ID',
-          ])
-          ->execute();
-        $this->assertIsNumeric($program_id,
+        $program_record = $this->dbxref_buddy->insertDb([
+          'db.name' => $program['name'],
+        ]);
+        $program_record_id = $program_record->getValue('db.db_id');
+        $this->assertIsNumeric($program_record_id,
           'We were not able to create the program "' . $program['name'] . '" in the db table for testing.');
-        $this->assertIsNumeric($dbprop_id,
+        // Create the dbprop record and link it to the db record.
+        $dbprop_id = $this->property_buddy->insertProperty('db', $program_record_id, [
+          'dbprop.type_id' => $cvterm_id,
+          'dbprop.value' => 'Program ID',
+        ]);
+        $this->assertIsNumeric($dbprop_id->getValue('dbprop.dbprop_id'),
           'We were not able to create the dbprop record for program "' . $program['name'] . '" for testing.');
       }
     }
@@ -409,7 +419,7 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     // Check that the select list contains all of our program IDs.
     foreach ($programs['programs'] as $program) {
       $this->assertArrayHasKey($program['name'], $form['program_id']['#options'],
-        "We expect the program_id select list to contain the program" . $program['name'] . ".");
+        "We expect the program_id select list to contain the program " . $program['name'] . ".");
     }
     // Check the select list's default value.
     $this->assertEquals($programs['default'], $form['program_id']['#default_value'],

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -374,14 +374,10 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
       'Year',
       'Season',
       'Cross Number',
-      'Unique Name',
       'Species',
       'Maternal Parent',
       'Paternal Parent',
       'Cross Type',
-      'Seed Type',
-      'Cotyledon Colour',
-      'Comment',
     ];
 
     // Pull all the headers in the rendered description.

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -177,7 +177,7 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
   public static function provideValuesForForm() {
     $scenarios = [];
 
-    // #0: No organisms & program IDs exist in the database.
+    // #0: No organisms or program IDs exist in the database.
     $scenarios[] = [
       [
         'organisms' => [],
@@ -191,7 +191,7 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
       ],
     ];
 
-    // #1: 1 valid organism
+    // #1: 1 valid organism + 1 valid program ID
     $scenarios[] = [
       [
         'organisms' => [
@@ -204,14 +204,17 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
         'message' => 'We expect the genus element in the form to default to Tripalus as it is the genus of the organism we created.',
       ],
       [
-        'programs' => [],
-        'default' => '',
-        'message' => 'We expect the program element in the form to default to empty option
-        since no programs are available.',
+        'programs' => [
+          [
+            'name' => 'Program 1',
+          ],
+        ],
+        'default' => 'Program 1',
+        'message' => 'We expect the program element in the form to default to Program 1 as it is the only program available.',
       ],
     ];
 
-    // #2: 3 valid organisms
+    // #2: 3 valid organisms + 3 valid Programs.
     $scenarios[] = [
       [
         'organisms' => [
@@ -234,10 +237,21 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
         'message' => 'We expect the genus element in the form to default to empty option since more than one organism is available.',
       ],
       [
-        'programs' => [],
+        'programs' => [
+          [
+            'name' => 'Program 1',
+          ],
+          [
+            'name' => 'Program 2',
+          ],
+          [
+            'name' => 'Program 3',
+          ],
+        ],
+        // Since there is more than one program, the default option is expected
+        // to be the -Select- text, therefore empty value.
         'default' => '',
-        'message' => 'We expect the program element in the form to default to empty option
-        since no programs are available.',
+        'message' => 'We expect the program element in the form to default to empty option since more than one program is available.',
       ],
     ];
 
@@ -265,9 +279,9 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
    *     contains the program name to create the form field dropdown. Each
    *     program array has the following keys:
    *     - 'name': A string of the program "code" to insert.
-   *   - The program name expected to be shown to the user by default.
-   *   - The string message to be passed into assertEquals when evaluating
-   *     the default program ID name.
+   *   - 'default': The program name expected to be shown by default.
+   *   - 'message': The string message to be passed into assertEquals when
+   *     evaluating the default program ID name.
    *
    * @dataProvider provideValuesForForm
    */
@@ -400,6 +414,16 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     // Check the select list's default value.
     $this->assertEquals($programs['default'], $form['program_id']['#default_value'],
       $programs['message']);
+
+    // If there are no programs to select from, we expect an error message to be
+    // displayed at the top of the form.
+    if (!$programs['programs']) {
+      $errors = \Drupal::messenger()->messagesByType('error');
+      $this->assertCount(1, $errors,
+        "We expect there to be an error message about no Program IDs being available.");
+      $this->assertStringContainsString('No Program IDs were found in the database', $errors[0],
+        "We expect the error message to contain a warning about no Program IDs being available.");
+    }
   }
 
   /**

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -288,19 +288,24 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
       }
     }
 
-    /*
     // Use a CVterm ChadoBuddy to get the cvterm_id for inserting Program IDs.
+    /*
     $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
     $cvterm_buddy = $buddy_service->createInstance('chado_cvterm_buddy', []);
+    $cv_record = $cvterm_buddy->insertCv([
+    'cv.name' => 'refs',
+    ]);
     $cvterm_record = $cvterm_buddy->insertCvterm([
-      'cv.name' => 'refs',
-      'cvterm.name' => 'type',
+    'cvterm.name' => 'type',
+    'buddy_record' => $cv_record,
     ]);
     $cvterm_id = $cvterm_record->getValue('cvterm_id');
     $this->assertIsNumeric($cvterm_id,
-      'We were not able to get the cvterm_id we need for creating Program ID dbprop records.');
+    'We were not able to get the cvterm_id we need for creating Program ID dbprop records.');
+     */
 
     // Insert any Program IDs if available.
+    $cvterm_id = '1';
     if ($programs['programs']) {
       foreach ($programs['programs'] as $program) {
         // Create the db record for this Program ID.
@@ -321,7 +326,6 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
           'We were not able to create the dbprop record for program "' . $program['name'] . '" for testing.');
       }
     }
-    */
 
     // Build the form using the Drupal form builder.
     $form = \Drupal::formBuilder()->getForm(
@@ -388,6 +392,20 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     // Check the select list's default value.
     $this->assertEquals($genus['default'], $form['genus']['#default_value'],
       $genus['message']);
+
+    // Check the Program ID form element.
+    $this->assertArrayHasKey('program_id', $form,
+      "We expect there to be an program_id form element but there is not.");
+    $this->assertEquals('select', $form['program_id']['#type'],
+      "We expect the program_id element in the form to be a select list.");
+    // Check that the select list contains all of our program IDs.
+    foreach ($programs['programs'] as $program) {
+      $this->assertArrayHasKey($program['name'], $form['program_id']['#options'],
+        "We expect the program_id select list to contain the program" . $program['name'] . ".");
+    }
+    // Check the select list's default value.
+    $this->assertEquals($programs['default'], $form['program_id']['#default_value'],
+      $programs['message']);
   }
 
   /**

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -10,7 +10,6 @@ use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoCvtermBuddy;
 use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoDbxrefBuddy;
-use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoPropertyBuddy;
 use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -72,13 +71,6 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
    * @var \Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoDbxrefBuddy
    */
   protected ChadoDbxrefBuddy $dbxref_buddy;
-
-  /**
-   * An instance of the ChadoPropertyBuddy.
-   *
-   * @var \Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoPropertyBuddy
-   */
-  protected ChadoPropertyBuddy $property_buddy;
 
   /**
    * A default listing of annotations associated with our importer.
@@ -159,7 +151,6 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
     $this->cvterm_buddy = $buddy_service->createInstance('chado_cvterm_buddy', []);
     $this->dbxref_buddy = $buddy_service->createInstance('chado_dbxref_buddy', []);
-    $this->property_buddy = $buddy_service->createInstance('chado_property_buddy', []);
   }
 
   /**
@@ -336,11 +327,14 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
         $this->assertIsNumeric($program_record_id,
           'We were not able to create the program "' . $program['name'] . '" in the db table for testing.');
         // Create the dbprop record and link it to the db record.
-        $dbprop_id = $this->property_buddy->insertProperty('db', $program_record_id, [
-          'dbprop.type_id' => $cvterm_id,
-          'dbprop.value' => 'Program ID',
-        ]);
-        $this->assertIsNumeric($dbprop_id->getValue('dbprop.dbprop_id'),
+        $dbprop_id = $this->chado_connection->insert('1:dbprop')
+          ->fields([
+            'db_id' => $program_record_id,
+            'type_id' => $cvterm_id,
+            'value' => 'Program ID',
+          ])
+          ->execute();
+        $this->assertIsNumeric($dbprop_id,
           'We were not able to create the dbprop record for program "' . $program['name'] . '" for testing.');
       }
     }

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormTest.php
@@ -464,7 +464,7 @@ class GermplasmCrossImporterFormTest extends ChadoTestKernelBase {
     $form_state = new FormState();
     $form_state->addBuildInfo('args', [$plugin_id]);
     $form_state->setValue('genus', $genus);
-    $form_state->setValue('program_id', $program_id);
+    $form_state->setValue('program_id', $program_name);
     $form_state->setValue('file_upload', $file->id());
 
     // Now try validation!

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
@@ -157,6 +157,36 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     $this->assertIsNumeric($organism_id_2,
       "We were not able to create an organism for testing.");
 
+    // Use a CVterm ChadoBuddy to get the cvterm_id for inserting Program IDs.
+    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+    $cvterm_buddy = $buddy_service->createInstance('chado_cvterm_buddy', []);
+    $cvterm_record = $cvterm_buddy->getCvterm([
+      'cv.name' => 'rdfs',
+      'cvterm.name' => 'type',
+    ]);
+    $cvterm_id = $cvterm_record[0]->getValue('cvterm.cvterm_id');
+    $this->assertIsNumeric($cvterm_id,
+    'We were not able to get the cvterm_id we need for creating Program ID dbprop records.');
+
+    $program_name = 'Test Program';
+    $program_id = $this->chado_connection->insert('1:db')
+      ->fields([
+        'name' => $program_name,
+      ])
+      ->execute();
+    // Create the dbprop record and link it to the db record.
+    $dbprop_id = $this->chado_connection->insert('1:dbprop')
+      ->fields([
+        'db_id' => $program_id,
+        'type_id' => $cvterm_id,
+        'value' => 'Program ID',
+      ])
+      ->execute();
+    $this->assertIsNumeric($program_id,
+          'We were not able to create the program "' . $program_name . '" in the db table for testing.');
+    $this->assertIsNumeric($dbprop_id,
+          'We were not able to create the dbprop record for program "' . $program_name . '" for testing.');
+
     // Insert test germplasm for Maternal Parent and Paternal Parent columns.
     // 121S and 122S appear as the value of both Maternal Germplasm and Paternal
     // Germplasm column-row combinations in the file:
@@ -192,6 +222,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
    * @return array
    *   Each scenario is an array with the following:
    *   - The genus that gets selected in the dropdown of the form
+   *   - The Program ID that gets selected in the dropdown of the form
    *   - The filename of the test file used for this scenario (test files are
    *     located in: tests/src/Fixtures/CrossImporterFiles/)
    *   - An array indicating the expected validation results:
@@ -212,10 +243,11 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
    */
   public static function provideFilesForValidation() {
 
-    // Set our default variables for genus.
-    // Since we created Tripalus databasica organism in our setup, we know that
-    // in this testing environment that the genus is databasica.
+    // Set our default variables for genus and program.
+    // Both of these value have been added in our setup, so we know they should
+    // be available.
     $valid_genus = 'Tripalus';
+    $valid_program = 'Test Program';
 
     $num_form_validation_messages = 0;
 
@@ -224,6 +256,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // #0: File is empty.
     $scenarios[] = [
       $valid_genus,
+      $valid_program,
       'empty_file.tsv',
       [
         'valid_data_file' => [
@@ -244,6 +277,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // #1: Header is improperly delimited, with proper data rows.
     $scenarios[] = [
       $valid_genus,
+      $valid_program,
       'improperly_delimited_header_with_data.tsv',
       [
         'valid_data_file' => ['status' => 'pass'],
@@ -264,6 +298,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // #2: 2nd row of file is improperly delimited.
     $scenarios[] = [
       $valid_genus,
+      $valid_program,
       'correct_header_improperly_delimited_data_row.tsv',
       [
         'valid_data_file' => ['status' => 'pass'],
@@ -287,6 +322,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // Never reaches the validators for data-row since file content is empty.
     $scenarios[] = [
       $valid_genus,
+      $valid_program,
       'correct_header_no_data.tsv',
       [
         'valid_data_file' => ['status' => 'pass'],
@@ -303,6 +339,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // #4: Contains incorrect header and one line of correct data.
     $scenarios[] = [
       $valid_genus,
+      $valid_program,
       'incorrect_header_with_data.tsv',
       [
         'valid_data_file' => ['status' => 'pass'],
@@ -323,6 +360,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // #5: Contains correct header + 1 line with empty Cross Number/Unique Name.
     $scenarios[] = [
       $valid_genus,
+      $valid_program,
       'correct_header_emptycell_crossnumber.tsv',
       [
         'valid_data_file' => ['status' => 'pass'],
@@ -343,6 +381,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // #6: Contains correct header and one line containing an invalid season.
     $scenarios[] = [
       $valid_genus,
+      $valid_program,
       'correct_header_invalid_season.tsv',
       [
         'valid_data_file' => ['status' => 'pass'],
@@ -363,6 +402,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // #7: Contains a non-existant maternal parent on row 3
     $scenarios[] = [
       $valid_genus,
+      $valid_program,
       'correct_header_nonexistent_maternal_parent.tsv',
       [
         'valid_data_file' => ['status' => 'pass'],
@@ -384,6 +424,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // even though the genus and the species exist separately.
     $scenarios[] = [
       $valid_genus,
+      $valid_program,
       'correct_header_nonexistent_organism.tsv',
       [
         'valid_data_file' => ['status' => 'pass'],
@@ -408,6 +449,8 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
    *
    * @param string $submitted_genus
    *   The genus that is submitted with the form.
+   * @param string $submitted_program
+   *   The Program ID that is submitted with the form.
    * @param string $filename
    *   The name of the file being tested. (Test files are located in
    *   tests/src/Fixtures/CrossImporterFiles/)
@@ -431,7 +474,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
    * @dataProvider provideFilesForValidation
    */
   #[DataProvider('provideFilesForValidation')]
-  public function testCrossFormValidation(string $submitted_genus, string $filename, array $expected_validator_results, int $expected_num_form_validation_errors) {
+  public function testCrossFormValidation(string $submitted_genus, string $submitted_program, string $filename, array $expected_validator_results, int $expected_num_form_validation_errors) {
 
     $formBuilder = \Drupal::formBuilder();
     $form_id = 'Drupal\tripal\Form\TripalImporterForm';
@@ -452,6 +495,9 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
 
     // Submit our genus.
     $form_state->setValue('genus', $submitted_genus);
+
+    // Submit our program ID.
+    $form_state->setValue('program_id', $submitted_program);
 
     // Submit our file.
     $form_state->setValue('file_upload', $file->id());

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
@@ -64,6 +64,10 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
   protected ChadoConnection $chado_connection;
 
   /**
+   *
+   */
+
+  /**
    * A default listing of annotations associated with our importer.
    *
    * @var array

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
@@ -64,10 +64,6 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
   protected ChadoConnection $chado_connection;
 
   /**
-   *
-   */
-
-  /**
    * A default listing of annotations associated with our importer.
    *
    * @var array
@@ -172,22 +168,23 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     $this->assertIsNumeric($cvterm_id,
     'We were not able to get the cvterm_id we need for creating Program ID dbprop records.');
 
+    // Use a dbxref buddy to get the db_id for inserting Program IDs.
     $program_name = 'Test Program';
-    $program_id = $this->chado_connection->insert('1:db')
-      ->fields([
-        'name' => $program_name,
-      ])
-      ->execute();
+    $dbxref_buddy = $buddy_service->createInstance('chado_dbxref_buddy', []);
+    $program_record = $dbxref_buddy->insertDb([
+      'db.name' => $program_name,
+    ]);
+    $program_record_id = $program_record->getValue('db.db_id');
+    $this->assertIsNumeric($program_record_id,
+      'We were not able to create the program "' . $program_name . '" in the db table for testing.');
     // Create the dbprop record and link it to the db record.
     $dbprop_id = $this->chado_connection->insert('1:dbprop')
       ->fields([
-        'db_id' => $program_id,
+        'db_id' => $program_record_id,
         'type_id' => $cvterm_id,
         'value' => 'Program ID',
       ])
       ->execute();
-    $this->assertIsNumeric($program_id,
-          'We were not able to create the program "' . $program_name . '" in the db table for testing.');
     $this->assertIsNumeric($dbprop_id,
           'We were not able to create the dbprop record for program "' . $program_name . '" for testing.');
 
@@ -195,29 +192,26 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // 121S and 122S appear as the value of both Maternal Germplasm and Paternal
     // Germplasm column-row combinations in the file:
     // correct_header_invalid_season.tsv.
-    $maternal_stock_id = $this->chado_connection->insert('1:stock')
-      ->fields([
-        'organism_id' => $organism_id_1,
-        'name' => '121S',
-        'dbxref_id' => 1,
-        'uniquename' => 'STOCK:121S',
-        'description' => '',
-        'type_id' => 1,
-        'is_obsolete' => 'f',
-      ])
-      ->execute();
+    $stock_buddy = $buddy_service->createInstance('chado_stock_buddy', []);
+    $maternal_stock = $stock_buddy->insertStock([
+      'stock.organism_id' => $organism_id_1,
+      'stock.name' => '121S',
+      'stock.dbxref_id' => 1,
+      'stock.uniquename' => 'STOCK:121S',
+      'stock.description' => '',
+      'stock.type_id' => 1,
+      'stock.is_obsolete' => 'f',
+    ]);
 
-    $paternal_stock_id = $this->chado_connection->insert('1:stock')
-      ->fields([
-        'organism_id' => $organism_id_1,
-        'name' => '122S',
-        'dbxref_id' => 1,
-        'uniquename' => 'STOCK:122S',
-        'description' => '',
-        'type_id' => 1,
-        'is_obsolete' => 'f',
-      ])
-      ->execute();
+    $paternal_stock = $stock_buddy->insertStock([
+      'stock.organism_id' => $organism_id_1,
+      'stock.name' => '122S',
+      'stock.dbxref_id' => 1,
+      'stock.uniquename' => 'STOCK:122S',
+      'stock.description' => '',
+      'stock.type_id' => 1,
+      'stock.is_obsolete' => 'f',
+    ]);
 
     // Insert a cross type for the Maternal and Paternal parents.
     $additionalType_cvterm = $cvterm_buddy->getCvterm([
@@ -228,14 +222,14 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     $additionalType_cvterm_id = $additionalType_cvterm[0]->getValue('cvterm.cvterm_id');
     $this->chado_connection->insert('1:stockprop')
       ->fields([
-        'stock_id' => $maternal_stock_id,
+        'stock_id' => $maternal_stock->getValue('stock.stock_id'),
         'type_id' => $additionalType_cvterm_id,
         'value' => 'single',
       ])
       ->execute();
     $this->chado_connection->insert('1:stockprop')
       ->fields([
-        'stock_id' => $paternal_stock_id,
+        'stock_id' => $paternal_stock->getValue('stock.stock_id'),
         'type_id' => $additionalType_cvterm_id,
         'value' => 'single',
       ])

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
@@ -270,7 +270,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_delimited_file' => [
           'title' => 'Lines are properly delimited',
           'status' => 'fail',
-          'details' => 'This importer requires a minimum number of 8 columns for each line. The following lines do not contain the expected number of columns.',
+          'details' => 'This importer requires a minimum number of 7 columns for each line. The following lines do not contain the expected number of columns.',
         ],
         // Since the header row has the correct number of columns, validation
         // for valid_header is expected to pass.

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
@@ -191,7 +191,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     // 121S and 122S appear as the value of both Maternal Germplasm and Paternal
     // Germplasm column-row combinations in the file:
     // correct_header_invalid_season.tsv.
-    $this->chado_connection->insert('1:stock')
+    $maternal_stock_id = $this->chado_connection->insert('1:stock')
       ->fields([
         'organism_id' => $organism_id_1,
         'name' => '121S',
@@ -203,7 +203,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
       ])
       ->execute();
 
-    $this->chado_connection->insert('1:stock')
+    $paternal_stock_id = $this->chado_connection->insert('1:stock')
       ->fields([
         'organism_id' => $organism_id_1,
         'name' => '122S',
@@ -212,6 +212,28 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
         'description' => '',
         'type_id' => 1,
         'is_obsolete' => 'f',
+      ])
+      ->execute();
+
+    // Insert a cross type for the Maternal and Paternal parents.
+    $additionalType_cvterm = $cvterm_buddy->getCvterm([
+      'cvterm.name' => 'additionalType',
+      'cv.name' => 'schema',
+      'dbxref.accession' => 'additionalType',
+    ]);
+    $additionalType_cvterm_id = $additionalType_cvterm[0]->getValue('cvterm.cvterm_id');
+    $this->chado_connection->insert('1:stockprop')
+      ->fields([
+        'stock_id' => $maternal_stock_id,
+        'type_id' => $additionalType_cvterm_id,
+        'value' => 'single',
+      ])
+      ->execute();
+    $this->chado_connection->insert('1:stockprop')
+      ->fields([
+        'stock_id' => $paternal_stock_id,
+        'type_id' => $additionalType_cvterm_id,
+        'value' => 'single',
       ])
       ->execute();
   }
@@ -270,6 +292,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_organism' => ['status' => 'todo'],
         'valid_season' => ['status' => 'todo'],
         'germplasm_name_exists' => ['status' => 'todo'],
+        'valid_cross_type' => ['status' => 'todo'],
       ],
       $num_form_validation_messages,
     ];
@@ -291,6 +314,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_organism' => ['status' => 'todo'],
         'valid_season' => ['status' => 'todo'],
         'germplasm_name_exists' => ['status' => 'todo'],
+        'valid_cross_type' => ['status' => 'todo'],
       ],
       $num_form_validation_messages,
     ];
@@ -314,6 +338,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_organism' => ['status' => 'todo'],
         'valid_season' => ['status' => 'todo'],
         'germplasm_name_exists' => ['status' => 'todo'],
+        'valid_cross_type' => ['status' => 'todo'],
       ],
       $num_form_validation_messages,
     ];
@@ -332,6 +357,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_organism' => ['status' => 'todo'],
         'valid_season' => ['status' => 'todo'],
         'germplasm_name_exists' => ['status' => 'todo'],
+        'valid_cross_type' => ['status' => 'todo'],
       ],
       $num_form_validation_messages,
     ];
@@ -353,6 +379,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_organism' => ['status' => 'todo'],
         'valid_season' => ['status' => 'todo'],
         'germplasm_name_exists' => ['status' => 'todo'],
+        'valid_cross_type' => ['status' => 'todo'],
       ],
       $num_form_validation_messages,
     ];
@@ -374,6 +401,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_organism' => ['status' => 'pass'],
         'valid_season' => ['status' => 'pass'],
         'germplasm_name_exists' => ['status' => 'pass'],
+        'valid_cross_type' => ['status' => 'pass'],
       ],
       $num_form_validation_messages,
     ];
@@ -395,11 +423,12 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
           'details' => 'The following line number and column combinations did not contain one of the following allowed values: "Winter", "Spring", "Summer", "Fall". Note that values should be case sensitive. <strong>If any cell in the table below is empty, then the value given in the file for that cell was one of the allowed values.</strong>',
         ],
         'germplasm_name_exists' => ['status' => 'pass'],
+        'valid_cross_type' => ['status' => 'pass'],
       ],
       $num_form_validation_messages,
     ];
 
-    // #7: Contains a non-existant maternal parent on row 3
+    // #7: Contains a non-existant maternal parent on row 3.
     $scenarios[] = [
       $valid_genus,
       $valid_program,
@@ -416,6 +445,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
           'status' => 'fail',
           'details' => 'The following germplasm names do not match any existing in this site. Please make sure you have entered the names exactly as they appear on the germplasm pages or contact your administrator to have them added if they do not yet exist.',
         ],
+        'valid_cross_type' => ['status' => 'pass'],
       ],
       $num_form_validation_messages,
     ];
@@ -438,9 +468,33 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
         ],
         'valid_season' => ['status' => 'pass'],
         'germplasm_name_exists' => ['status' => 'pass'],
+        'valid_cross_type' => ['status' => 'pass'],
       ],
       $num_form_validation_messages,
     ];
+
+    // #9: Contains correct header and one line containing an invalid crosstype.
+    $scenarios[] = [
+      $valid_genus,
+      $valid_program,
+      'correct_header_invalid_cross_type.tsv',
+      [
+        'valid_data_file' => ['status' => 'pass'],
+        'valid_delimited_file' => ['status' => 'pass'],
+        'valid_header' => ['status' => 'pass'],
+        'empty_cell' => ['status' => 'pass'],
+        'valid_organism' => ['status' => 'pass'],
+        'valid_season' => ['status' => 'pass'],
+        'germplasm_name_exists' => ['status' => 'pass'],
+        'valid_cross_type' => [
+          'title' => 'Values in column "Cross Type" are valid',
+          'status' => 'fail',
+          'details' => 'The following line number and column combinations did not contain one of the following allowed values: "single". Note that values should be case sensitive. <strong>If any cell in the table below is empty, then the value given in the file for that cell was one of the allowed values.</strong>',
+        ],
+      ],
+      $num_form_validation_messages,
+    ];
+
     return $scenarios;
   }
 

--- a/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
+++ b/trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmCrossImporter/GermplasmCrossImporterFormValidateTest.php
@@ -584,6 +584,15 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
       'The import form should set the default value of genus to the genus entered if the form was not submitted due to validation error.'
     );
 
+    // Assert that the default value of program ID field is the one that was
+    // entered/selected, indicating that on form validate error, the form was
+    // not submitted and reloaded with the genus value as default.
+    $this->assertEquals(
+      $form_state->getValue('program_id'),
+      $submitted_program,
+      'The import form should set the default value of program ID to the program ID entered if the form was not submitted due to validation error.'
+    );
+
     // If the form was not submitted due to validation error, check to ensure
     // that no Tripal Job was created in the process.
     $tripal_jobs = $this->chado_connection->query(
@@ -603,6 +612,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
    * @return array
    *   Each scenario is an array with the following:
    *   - The genus that gets selected in the dropdown of the form.
+   *   - The Program ID that gets selected in the dropdown of the form.
    *   - The filename of the test file used for this scenario.
    *   - The expected exception message when the selected genus is not valid.
    */
@@ -610,11 +620,13 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
     return [
       'no_genus_selected' => [
         'input_genus' => '',
+        'input_program' => 'Test Program',
         'input_file' => 'correct_header_no_data.tsv',
         'expected_exception' => 'Cannot retrieve an array of organism IDs as one has not been set by either the setOrganismID() or setGenus() method.',
       ],
       'nonexistent_genus_selected' => [
         'input_genus' => 'NonexistentGenus',
+        'input_program' => 'Test Program',
         'input_file' => 'correct_header_no_data.tsv',
         'expected_exception' => 'Cannot retrieve an array of organism IDs as one has not been set by either the setOrganismID() or setGenus() method.',
       ],
@@ -626,6 +638,8 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
    *
    * @param string $input_genus
    *   The genus that is submitted with the form.
+   * @param string $input_program
+   *   The Program ID that is submitted with the form.
    * @param string $input_file
    *   The name of the file being tested.
    * @param string $expected_exception
@@ -634,7 +648,7 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
    * @dataProvider provideFilesForValidationWithExceptions
    */
   #[DataProvider('provideFilesForValidationWithExceptions')]
-  public function testCrossFormValidationWithExceptions(string $input_genus, string $input_file, string $expected_exception) {
+  public function testCrossFormValidationWithExceptions(string $input_genus, string $input_program, string $input_file, string $expected_exception) {
     $formBuilder = \Drupal::formBuilder();
     $form_id = 'Drupal\tripal\Form\TripalImporterForm';
     $plugin_id = 'trpcultivate-germplasm-cross-importer';
@@ -654,6 +668,9 @@ class GermplasmCrossImporterFormValidateTest extends ChadoTestKernelBase {
 
     // Submit our genus.
     $form_state->setValue('genus', $input_genus);
+
+    // Submit our program ID.
+    $form_state->setValue('program_id', $input_program);
 
     // Submit our file.
     $form_state->setValue('file_upload', $file->id());


### PR DESCRIPTION
**Issue #58**

## Motivation

The expected input file format for the Germplasm Cross Importer needs to be updated to reflect the broader breeding community that this module aims to support. As well, users should now be able to specify their Breeding Program ID (represented as a string that we will likely assign to each program ourselves) when importing their crosses. Lastly, the "Cross Type" currently has no validation but it probably should 😉 

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.*

1. Adds a dropdown to the importer form to select from available Program IDs which indicate the breeding program for these crosses. This will be stored as the stock's dbxref.

2. Updates the file format from having 11 column headers down to these 7:
   - Year
   - Season
   - Cross Number
   - Species
   - Maternal Parent
   - Paternal Parent
   - Cross Type

3. Adds validation for the "Cross Type" column in `formValidate()`.

## Testing

### Automated Testing
Updates to `GermplasmCrossImporterFormTest`:
- Function `provideGenusForForm()` was renamed to `provideValuesForForm()` so that both Genus and Program ID values could be provided.
- Parameters were updated for `testCrossImporterForm()` to take 1 array each for Genus, Program ID
- Program IDs for testing now get created in `testCrossImporterForm()` and `testCrossImporterFormSubmitValid()`
- The Program ID form element is tested in `testCrossImporterForm()`

Updates to `GermplasmCrossImporterFormValidateTest`:
- Test Program IDs, maternal/paternal stocks, and cross types are now being created in `setUp()`
- Test Program ID was added to all scenarios in `provideFilesForValidation()`, `provideFilesForValidationWithExceptions()`
- A new scenario was added to `provideFilesForValidation()` for testing invalid Cross Type

### Manual Testing
1. Start a docker container on branch `g2.58-germplasmCrossImporterRun`

2. You can create 1+ organisms in your site either by navigating to Tripal > Content > Add Tripal Content > Add Organism OR you can refer to the manual testing for [this PR](https://github.com/tripal/tripal/pull/2539) and use the ChadoOrganismBuddy. It is recommended to create `Tripalus databasica` if using the module's own test file fixtures in steps 9-10.

3. Create new germplasm of type "Breeding Cross Progeny" by navigating to Tripal > Content > Add Tripal Content > Breeding Cross Progeny with the same organism you created in step 2. If you'd like to import using the test files located in `tests/src/Fixtures/CrossImporterFiles`, I recommend germplasm names "121S", "122S" and "124S".

4. Either use PHP from the command line, or login to your TripalCultivate site and navigate to the URL `yoursite/devel/php`, then create a cross type for the maternal and parental parents:
```
// Use the ChadoCvtermBuddy to grab the correct cvterm
$type = \Drupal::service('tripal_chado.chado_buddy');
$cvterm_buddy = $type->createInstance('chado_cvterm_buddy', []);
$additionalType_cvterm = $cvterm_buddy->getCvterm([
   'cvterm.name' => 'additionalType',
   'cv.name' => 'schema',
   'dbxref.accession' => 'additionalType',
]);
$additionalType_cvterm_id = $additionalType_cvterm[0]->getValue('cvterm.cvterm_id');
// Now insert into stockprop
$chado_connection = \Drupal::service('tripal_chado.database');
$chado_connection->insert('1:stockprop')
   ->fields([
     'stock_id' => 1,
     'type_id' => $additionalType_cvterm_id,
     'value' => 'single',
   ])
   ->execute();
$chado_connection->insert('1:stockprop')
   ->fields([
     'stock_id' => 2,
     'type_id' => $additionalType_cvterm_id,
     'value' => 'single',
   ])
   ->execute();
```

5. Double check that your cross types are there:
```
$chado_connection = \Drupal::service('tripal_chado.database');
$stockprop_query = $chado_connection->select('1:stockprop', 'sp')
  ->fields('sp');
$results = $stockprop_query->execute()->fetchAll();
print_r($results);
```

<img width="493" height="489" alt="image" src="https://github.com/user-attachments/assets/3925f9e3-ac62-4916-b518-76faad7a3d80" />


6. Create Program IDs for testing:
```
// Use the ChadoCvtermBuddy to grab the cvterm for our Program IDs
$type = \Drupal::service('tripal_chado.chado_buddy');
$cvterm_buddy = $type->createInstance('chado_cvterm_buddy', []);
$cvterm_record = $cvterm_buddy->getCvterm([
   'cv.name' => 'rdfs',
   'cvterm.name' => 'type',
]);
$cvterm_id = $cvterm_record[0]->getValue('cvterm.cvterm_id');

// Choose the names of your program IDs here:
$program_IDs = ['Lentil', 'Wheat'];

// Use the ChadoDbxrefBuddy to insert our Program ID(s)
$dbxref_buddy = $type->createInstance('chado_dbxref_buddy', []);
foreach ($program_IDs as $program) {
  // Create the db record for this Program ID.
  $program_record = $dbxref_buddy->insertDb([
     'db.name' => $program,
  ]);
  $program_record_id = $program_record->getValue('db.db_id');
  // Create the dbprop record and link it to the db record.
  $chado_connection = \Drupal::service('tripal_chado.database');
  $dbprop_id = $chado_connection->insert('1:dbprop')
     ->fields([
       'db_id' => $program_record_id,
       'type_id' => $cvterm_id,
       'value' => 'Program ID',
     ])
     ->execute();
}
```

7. Check that your Program IDs were successfully created:
```
$chado_connection = \Drupal::service('tripal_chado.database');
$programs_query = $chado_connection->select('1:db', 'db')
  ->fields('db', ['name']);
$programs_query->join('1:dbprop', 'dbp', 'db.db_id = dbp.db_id');
$programs_query->condition('dbp.value', 'Program ID', '=');
$programs_query->orderBy('db.name')
  ->distinct();

$results = $programs_query->execute()->fetchAll();
print_r($results);
```

<img width="424" height="374" alt="image" src="https://github.com/user-attachments/assets/0f678467-658d-4f00-911c-7b9442be418b" />

8. Navigate to the Germplasm Cross Importer in your site: Tripal > Data Loaders > Tripal Cultivate: Germplasm Cross Importer

9. Check that the `Genus` and `Program ID` fields are populated with the records you created in steps 2 & 6.

10. Check the File format listed on the page AND download the template file to ensure they both reflect the following 7 required columns:
<img width="1008" height="487" alt="image" src="https://github.com/user-attachments/assets/05cdc2ba-2d62-4c41-be6a-5a57a59bc0b1" />

11. Test that validation of "Cross Type" is working by uploading the following file: [correct_header_invalid_cross_type.tsv](https://github.com/TripalCultivate/TripalCultivate-Germplasm/blob/g2.58-germplasmCrossImporterRun/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles/correct_header_invalid_cross_type.tsv)

12. Test that the remaining test files are still behaving as expected during validation. See:
https://github.com/TripalCultivate/TripalCultivate-Germplasm/tree/g2.58-germplasmCrossImporterRun/trpcultivate_germplasm/tests/src/Fixtures/CrossImporterFiles
